### PR TITLE
git ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
 .*
+*.cmake
+*~
+*.so
+core
+Makefile
+CMakeCache.txt
+CMakeFiles
+Testing
+
 !.gitignore
 !.gitattributes
 !.clang-format


### PR DESCRIPTION
Hide some generic junk.  This does not include actually built binaries, tests' private dirs, etc — would be nice to add them later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/12)
<!-- Reviewable:end -->
