### PR TITLE
critnib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES
 	mmap.c
 	mmap_posix.c
 	libvmemcache.c
+	critnib.c
 	ravl.c
 	vmemcache.c
 	vmemcache_heap.c

--- a/src/critnib.c
+++ b/src/critnib.c
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2018-2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "os_thread.h"
+#include "util.h"
+#include "out.h"
+#include "critnib.h"
+
+/*
+ * WARNING: this implementation fails badly if you try to store two keys
+ * where one is a prefix of another.  Pass a struct { int len; char[] key; }
+ * or such if such keys are possible.
+ */
+
+/*
+ * SLICE may be 1, 2, 4 or 8.  1 or 8 could be further optimized (critbit
+ * and critbyte respectively); 4 (critnib) strikes a good balance between
+ * speed and memory use.
+ */
+#define SLICE 4
+#define NIB ((1ULL << SLICE) - 1)
+#define SLNODES (1 << SLICE)
+
+typedef uint32_t byten_t;
+typedef unsigned char bitn_t;
+
+struct critnib_node {
+	struct critnib_node *child[SLNODES];
+	byten_t byte;
+	bitn_t bit;
+};
+
+struct critnib_leaf {
+	const char *key;
+	byten_t key_len;
+	void *value;
+};
+
+struct critnib {
+	struct critnib_node *root;
+	os_mutex_t mutex;
+};
+
+/*
+ * is_leaf -- (internal) check tagged pointer for leafness
+ */
+static inline bool
+is_leaf(struct critnib_node *n)
+{
+	return (uint64_t)n & 1;
+}
+
+/*
+ * to_leaf -- (internal) untag a leaf pointer
+ */
+static inline struct critnib_leaf *
+to_leaf(struct critnib_node *n)
+{
+	return (void *)((uint64_t)n & ~1ULL);
+}
+
+/*
+ * slice_index -- (internal) get index of radix child at a given shift
+ */
+static inline int
+slice_index(char b, bitn_t bit)
+{
+	return (b >> bit) & NIB;
+}
+
+/*
+ * critnib_new -- allocate a new hashmap
+ */
+struct critnib *
+critnib_new(void)
+{
+	struct critnib *c = Malloc(sizeof(struct critnib));
+	if (!c)
+		return NULL;
+	os_mutex_init(&c->mutex);
+	c->root = NULL;
+	return c;
+}
+
+/*
+ * delete_node -- (internal) recursively free a subtree
+ */
+static void
+delete_node(struct critnib_node *n)
+{
+	if (!n)
+		return;
+	if (is_leaf(n))
+		return Free(to_leaf(n));
+	for (int i = 0; i < SLNODES; i++)
+		delete_node(n->child[i]);
+}
+
+/*
+ * critnib_delete -- free a hashmap
+ */
+void
+critnib_delete(struct critnib *c)
+{
+	os_mutex_destroy(&c->mutex);
+	delete_node(c->root);
+	Free(c);
+}
+
+/*
+ * alloc_node -- (internal) alloc a node
+ */
+static struct critnib_node *
+alloc_node(struct critnib *c)
+{
+	struct critnib_node *n = Zalloc(sizeof(struct critnib_node));
+	if (!n)
+		return NULL;
+	for (int i = 0; i < SLNODES; i++)
+		n->child[i] = NULL;
+	return n;
+}
+
+/*
+ * alloc_leaf -- (internal) alloc a leaf
+ */
+static struct critnib_leaf *
+alloc_leaf(struct critnib *c)
+{
+	return Malloc(sizeof(struct critnib_leaf));
+}
+
+/*
+ * any_leaf -- (internal) find any leaf in a subtree
+ *
+ * We know they're all identical up to the divergence point between a prefix
+ * shared by all of them vs the new key we're inserting.
+ */
+static struct critnib_node *
+any_leaf(struct critnib_node *n)
+{
+	for (int i = 0; i < SLNODES; i++) {
+		struct critnib_node *m;
+		if ((m = n->child[i]))
+			return is_leaf(m) ? m : any_leaf(m);
+	}
+	return NULL;
+}
+
+/*
+ * critnib_set -- insert a new entry
+ */
+int
+critnib_set(struct critnib *c, struct cache_entry *e)
+{
+	struct critnib_leaf *k = alloc_leaf(c);
+	if (!k)
+		return ENOMEM;
+
+	const char *key = (void *)&e->key;
+	byten_t key_len = (byten_t)(e->key.ksize + sizeof(e->key.ksize));
+	k->key = key;
+	k->key_len = key_len;
+	k->value = e;
+	k = (void *)((uint64_t)k | 1);
+
+	os_mutex_lock(&c->mutex);
+	struct critnib_node *n = c->root;
+	if (!n) {
+		c->root = (void *)k;
+		os_mutex_unlock(&c->mutex);
+		return 0;
+	}
+
+	/*
+	 * Need to descend the tree twice: first to find a leaf that
+	 * represents a subtree whose all keys share a prefix at least as
+	 * long as the one common to the new key and that subtree.
+	 */
+	while (!is_leaf(n) && n->byte < key_len) {
+		struct critnib_node *nn =
+			n->child[slice_index(key[n->byte], n->bit)];
+		if (nn)
+			n = nn;
+		else {
+			n = any_leaf(n);
+			break;
+		}
+	}
+
+	ASSERT(n);
+	if (!is_leaf(n))
+		n = any_leaf(n);
+
+	ASSERT(n);
+	ASSERT(is_leaf(n));
+	struct critnib_leaf *nk = to_leaf(n);
+
+	/* Find the divergence point, accurate to a byte. */
+	byten_t common_len = (nk->key_len < (byten_t)key_len)
+			    ? nk->key_len : (byten_t)key_len;
+	byten_t diff;
+	for (diff = 0; diff < common_len; diff++) {
+		if (nk->key[diff] != key[diff])
+			break;
+	}
+
+	if (diff >= common_len) {
+		/*
+		 * Either an update or a conflict between keys being a
+		 * prefix of each other.
+		 */
+		return EEXIST;
+	}
+
+	/* Calculate the divergence point within the single byte. */
+	char at = nk->key[diff] ^ key[diff];
+	bitn_t sh = util_mssb_index((uint32_t)at) & (bitn_t)~(SLICE - 1);
+
+	/* Descend into the tree again. */
+	n = c->root;
+	struct critnib_node **parent = &c->root;
+	while (n && !is_leaf(n) &&
+			(n->byte < diff || (n->byte == diff && n->bit >= sh))) {
+		parent = &n->child[slice_index(key[n->byte], n->bit)];
+		n = *parent;
+	}
+
+	/*
+	 * If the divergence point is at same nib as an existing node, and
+	 * the subtree there is empty, just place our leaf there and we're
+	 * done.  Obviously this can't happen if SLICE == 1.
+	 */
+	if (!n) {
+		*parent = (void *)k;
+		os_mutex_unlock(&c->mutex);
+		return 0;
+	}
+
+	/* If not, we need to insert a new node in the middle of an edge. */
+	if (!(n = alloc_node(c))) {
+		os_mutex_unlock(&c->mutex);
+		Free(k);
+		return ENOMEM;
+	}
+
+	n->child[slice_index(nk->key[diff], sh)] = *parent;
+	n->child[slice_index(key[diff], sh)] = (void *)k;
+	n->byte = diff;
+	n->bit = sh;
+	*parent = n;
+	os_mutex_unlock(&c->mutex);
+	return 0;
+}
+
+/*
+ * critnib_get -- query a key
+ */
+void *
+critnib_get(struct critnib *c, const struct cache_entry *e)
+{
+	const char *key = (void *)&e->key;
+	byten_t key_len = (byten_t)(e->key.ksize + sizeof(e->key.ksize));
+
+	os_mutex_lock(&c->mutex);
+	struct critnib_node *n = c->root;
+	while (n && !is_leaf(n)) {
+		if (n->byte >= key_len) {
+			os_mutex_unlock(&c->mutex);
+			return NULL;
+		}
+		n = n->child[slice_index(key[n->byte], n->bit)];
+	}
+
+	if (!n) {
+		os_mutex_unlock(&c->mutex);
+		return NULL;
+	}
+
+	struct critnib_leaf *k = to_leaf(n);
+
+	/*
+	 * We checked only nibs at divergence points, have to re-check the
+	 * whole key.
+	 */
+	void *value = (key_len != k->key_len || memcmp(key, k->key, key_len)) ?
+		NULL : k->value;
+	os_mutex_unlock(&c->mutex);
+	return value;
+}
+
+/*
+ * critnib_remove -- query and delete a key
+ *
+ * Neither the key nor its value are freed, just our private nodes.
+ */
+void *
+critnib_remove(struct critnib *c, const struct cache_entry *e)
+{
+	const char *key = (void *)&e->key;
+	byten_t key_len = (byten_t)(e->key.ksize + sizeof(e->key.ksize));
+
+	os_mutex_lock(&c->mutex);
+	struct critnib_node **pp = NULL;
+	struct critnib_node *n = c->root;
+	struct critnib_node **parent = &c->root;
+
+	/* First, do a get. */
+	while (n && !is_leaf(n)) {
+		if (n->byte >= key_len) {
+			os_mutex_unlock(&c->mutex);
+			return NULL;
+		}
+		pp = parent;
+		parent = &n->child[slice_index(key[n->byte], n->bit)];
+		n = *parent;
+	}
+
+	if (!n) {
+		os_mutex_unlock(&c->mutex);
+		return NULL;
+	}
+
+	struct critnib_leaf *k = to_leaf(n);
+	if (key_len != k->key_len || memcmp(key, k->key, key_len)) {
+		os_mutex_unlock(&c->mutex);
+		return NULL;
+	}
+
+	void *value = k->value;
+
+	/* Remove the entry (leaf). */
+	*parent = NULL;
+	Free(k);
+
+	if (!pp) { /* was root */
+		os_mutex_unlock(&c->mutex);
+		return value;
+	}
+
+	/* Check if after deletion the node has just a single child left. */
+	n = *pp;
+	struct critnib_node *only_child = NULL;
+	for (int i = 0; i < SLNODES; i++) {
+		if (n->child[i]) {
+			if (only_child) {
+				/* Nope. */
+				os_mutex_unlock(&c->mutex);
+				return value;
+			}
+			only_child = n->child[i];
+		}
+	}
+
+	/* Yes -- shorten the tree's edge. */
+	ASSERT(only_child);
+	*pp = only_child;
+	os_mutex_unlock(&c->mutex);
+	Free(n);
+	return value;
+}

--- a/src/critnib.c
+++ b/src/critnib.c
@@ -72,7 +72,6 @@ struct critnib_leaf {
 
 struct critnib {
 	struct critnib_node *root;
-	os_mutex_t mutex;
 };
 
 /*
@@ -111,7 +110,6 @@ critnib_new(void)
 	struct critnib *c = Malloc(sizeof(struct critnib));
 	if (!c)
 		return NULL;
-	os_mutex_init(&c->mutex);
 	c->root = NULL;
 	return c;
 }
@@ -136,7 +134,6 @@ delete_node(struct critnib_node *n)
 void
 critnib_delete(struct critnib *c)
 {
-	os_mutex_destroy(&c->mutex);
 	delete_node(c->root);
 	Free(c);
 }
@@ -198,11 +195,9 @@ critnib_set(struct critnib *c, struct cache_entry *e)
 	k->value = e;
 	k = (void *)((uint64_t)k | 1);
 
-	os_mutex_lock(&c->mutex);
 	struct critnib_node *n = c->root;
 	if (!n) {
 		c->root = (void *)k;
-		os_mutex_unlock(&c->mutex);
 		return 0;
 	}
 
@@ -267,13 +262,11 @@ critnib_set(struct critnib *c, struct cache_entry *e)
 	 */
 	if (!n) {
 		*parent = (void *)k;
-		os_mutex_unlock(&c->mutex);
 		return 0;
 	}
 
 	/* If not, we need to insert a new node in the middle of an edge. */
 	if (!(n = alloc_node(c))) {
-		os_mutex_unlock(&c->mutex);
 		Free(k);
 		return ENOMEM;
 	}
@@ -283,7 +276,6 @@ critnib_set(struct critnib *c, struct cache_entry *e)
 	n->byte = diff;
 	n->bit = sh;
 	*parent = n;
-	os_mutex_unlock(&c->mutex);
 	return 0;
 }
 
@@ -296,20 +288,15 @@ critnib_get(struct critnib *c, const struct cache_entry *e)
 	const char *key = (void *)&e->key;
 	byten_t key_len = (byten_t)(e->key.ksize + sizeof(e->key.ksize));
 
-	os_mutex_lock(&c->mutex);
 	struct critnib_node *n = c->root;
 	while (n && !is_leaf(n)) {
-		if (n->byte >= key_len) {
-			os_mutex_unlock(&c->mutex);
+		if (n->byte >= key_len)
 			return NULL;
-		}
 		n = n->child[slice_index(key[n->byte], n->bit)];
 	}
 
-	if (!n) {
-		os_mutex_unlock(&c->mutex);
+	if (!n)
 		return NULL;
-	}
 
 	struct critnib_leaf *k = to_leaf(n);
 
@@ -317,10 +304,8 @@ critnib_get(struct critnib *c, const struct cache_entry *e)
 	 * We checked only nibs at divergence points, have to re-check the
 	 * whole key.
 	 */
-	void *value = (key_len != k->key_len || memcmp(key, k->key, key_len)) ?
+	return (key_len != k->key_len || memcmp(key, k->key, key_len)) ?
 		NULL : k->value;
-	os_mutex_unlock(&c->mutex);
-	return value;
 }
 
 /*
@@ -334,32 +319,25 @@ critnib_remove(struct critnib *c, const struct cache_entry *e)
 	const char *key = (void *)&e->key;
 	byten_t key_len = (byten_t)(e->key.ksize + sizeof(e->key.ksize));
 
-	os_mutex_lock(&c->mutex);
 	struct critnib_node **pp = NULL;
 	struct critnib_node *n = c->root;
 	struct critnib_node **parent = &c->root;
 
 	/* First, do a get. */
 	while (n && !is_leaf(n)) {
-		if (n->byte >= key_len) {
-			os_mutex_unlock(&c->mutex);
+		if (n->byte >= key_len)
 			return NULL;
-		}
 		pp = parent;
 		parent = &n->child[slice_index(key[n->byte], n->bit)];
 		n = *parent;
 	}
 
-	if (!n) {
-		os_mutex_unlock(&c->mutex);
+	if (!n)
 		return NULL;
-	}
 
 	struct critnib_leaf *k = to_leaf(n);
-	if (key_len != k->key_len || memcmp(key, k->key, key_len)) {
-		os_mutex_unlock(&c->mutex);
+	if (key_len != k->key_len || memcmp(key, k->key, key_len))
 		return NULL;
-	}
 
 	void *value = k->value;
 
@@ -367,21 +345,16 @@ critnib_remove(struct critnib *c, const struct cache_entry *e)
 	*parent = NULL;
 	Free(k);
 
-	if (!pp) { /* was root */
-		os_mutex_unlock(&c->mutex);
+	if (!pp) /* was root */
 		return value;
-	}
 
 	/* Check if after deletion the node has just a single child left. */
 	n = *pp;
 	struct critnib_node *only_child = NULL;
 	for (int i = 0; i < SLNODES; i++) {
 		if (n->child[i]) {
-			if (only_child) {
-				/* Nope. */
-				os_mutex_unlock(&c->mutex);
+			if (only_child) /* Nope. */
 				return value;
-			}
 			only_child = n->child[i];
 		}
 	}
@@ -389,7 +362,6 @@ critnib_remove(struct critnib *c, const struct cache_entry *e)
 	/* Yes -- shorten the tree's edge. */
 	ASSERT(only_child);
 	*pp = only_child;
-	os_mutex_unlock(&c->mutex);
 	Free(n);
 	return value;
 }

--- a/src/critnib.h
+++ b/src/critnib.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "vmemcache.h"
+
+struct critnib;
+
+struct critnib *critnib_new(void);
+void critnib_delete(struct critnib *c);
+int critnib_set(struct critnib *c, struct cache_entry *e);
+void *critnib_get(struct critnib *c, const struct cache_entry *e);
+void *critnib_remove(struct critnib *c, const struct cache_entry *e);

--- a/src/critnib.h
+++ b/src/critnib.h
@@ -33,6 +33,7 @@
 #include "vmemcache.h"
 
 struct critnib;
+struct cache_entry;
 
 struct critnib *critnib_new(void);
 void critnib_delete(struct critnib *c);

--- a/src/vmemcache_index.h
+++ b/src/vmemcache_index.h
@@ -38,13 +38,13 @@
 #define VMEMCACHE_INDEX_H 1
 
 #include "libvmemcache.h"
-#include "ravl.h"
+#include "critnib.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct ravl vmemcache_index_t;
+typedef struct critnib vmemcache_index_t;
 struct cache_entry;
 
 vmemcache_index_t *vmcache_index_new(void);


### PR DESCRIPTION
Replace the index structure.

As the master branch has no real code yet, the real dev branch cherry-picked atop this is available as kilobyte/critnib-tests

Ravl is not yet removed from the tree, for ease of debugging/comparing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/13)
<!-- Reviewable:end -->
