### PR TITLE
WIP rwlock for the index

### DIFF
--- a/src/critnib.h
+++ b/src/critnib.h
@@ -39,7 +39,8 @@
 struct critnib_node;
 struct critnib {
 	struct critnib_node *root;
-	os_mutex_t lock;
+	volatile uint64_t xlock;
+	os_mutex_t wmutex;
 };
 
 struct cache_entry;


### PR DESCRIPTION
Here's a lock that allows multiple concurrent readers.  Unlike pthreads' rwlock, it doesn't starve either side — but alas, it leaves a lot of room for performance improvements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/25)
<!-- Reviewable:end -->
