### PR TITLE
silence warnings in check-license

### DIFF
--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -288,8 +288,7 @@ create_pattern(const char *path_license, char *pattern)
 	if (analyze_license(path_license, buffer, &license) == -1)
 		return -1;
 
-	memset(pattern, 0, LICENSE_MAX_LEN);
-	strncpy(pattern, license, strlen(license) + 1);
+	strncpy(pattern, license, LICENSE_MAX_LEN);
 
 	return 0;
 }

--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -184,7 +184,8 @@ format_license(char *license, size_t length)
 	/* is there any comment? */
 	if (comment + 1 != license) {
 		/* separate out a comment */
-		strncpy(comment_str, comment, COMMENT_STR_LEN);
+		strncpy(comment_str, comment, COMMENT_STR_LEN - 1);
+		comment_str[COMMENT_STR_LEN - 1] = 0;
 		comment = comment_str + 1;
 		while (isspace(*comment))
 			comment++;


### PR DESCRIPTION
This fixes a couple of warnings when compiling check-license with a new enough gcc.

Don't even try reading the code — it'll make you weep and lose the last shreds of faith in humanity.  It mixes C strings with null-padded-not-terminated buffers, which almost always _are_ filled to the brim, thus not exploding only because the random memory past the end tends to be 0 — and that's just some of the badness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/26)
<!-- Reviewable:end -->
