### PR TITLE
repl: make _use and _evict take a reference to the pointer

### DIFF
--- a/src/vmemcache_repl.h
+++ b/src/vmemcache_repl.h
@@ -63,12 +63,12 @@ struct repl_p_ops {
 	/* evict an/the element */
 	void *
 		(*repl_p_evict)(struct repl_p_head *head,
-					struct repl_p_entry *entry);
+					struct repl_p_entry **ptr_entry);
 
 	/* use the element */
 	void
 		(*repl_p_use)(struct repl_p_head *head,
-					struct repl_p_entry *entry);
+					struct repl_p_entry **ptr_entry);
 };
 
 struct repl_p {


### PR DESCRIPTION
The pointer to an element of the replacement policy list's
can be accessed (read and written) only under the lock
inside the replacement policy module in order to avoid
race conditions. This is a continuation of the incomplete
fix e89a003f.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/27)
<!-- Reviewable:end -->
