### PR TITLE
move variable sized type to the end of a struct

### DIFF
--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -94,8 +94,8 @@ vmcache_index_get(vmemcache_index_t *index, const char *key, size_t ksize,
 	struct cache_entry *e;
 
 	struct static_buffer {
-		struct cache_entry entry;
 		char key[SIZE_1K];
+		struct cache_entry entry;
 	} sb;
 
 	*entry = NULL;


### PR DESCRIPTION
The field 'entry' has variable sized type 'struct cache_entry'
and should be placed at the end of a struct, otherwise it can
cause the following warning:
```
/vmemcache/src/vmemcache_index.c:97:22: warning: field 'entry' 
           with variable sized type 'struct cache_entry' not at the end
           of a struct or class is a GNU extension 
           [-Wgnu-variable-sized-type-not-at-end]
                struct cache_entry entry;
                                   ^
1 warning generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/32)
<!-- Reviewable:end -->
