### PR TITLE
fix a sign conversion warning

### DIFF
--- a/src/critnib.c
+++ b/src/critnib.c
@@ -52,7 +52,7 @@
  * speed and memory use.
  */
 #define SLICE 4
-#define NIB ((1ULL << SLICE) - 1)
+#define NIB ((1 << SLICE) - 1)
 #define SLNODES (1 << SLICE)
 
 typedef uint32_t byten_t;


### PR DESCRIPTION
I can't reproduce locally (without an older environment), but travis runs an older version of gcc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/33)
<!-- Reviewable:end -->
