### PR TITLE
Fix using multiple caches

### DIFF
--- a/src/critnib.c
+++ b/src/critnib.c
@@ -70,10 +70,6 @@ struct critnib_leaf {
 	void *value;
 };
 
-struct critnib {
-	struct critnib_node *root;
-};
-
 /*
  * is_leaf -- (internal) check tagged pointer for leafness
  */

--- a/src/critnib.h
+++ b/src/critnib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef CRITNIB_H
+#define CRITNIB_H
+
 #include "vmemcache.h"
 
 struct critnib;
@@ -40,3 +43,5 @@ void critnib_delete(struct critnib *c);
 int critnib_set(struct critnib *c, struct cache_entry *e);
 void *critnib_get(struct critnib *c, const struct cache_entry *e);
 void *critnib_remove(struct critnib *c, const struct cache_entry *e);
+
+#endif

--- a/src/critnib.h
+++ b/src/critnib.h
@@ -34,8 +34,14 @@
 #define CRITNIB_H
 
 #include "vmemcache.h"
+#include "os_thread.h"
 
-struct critnib;
+struct critnib_node;
+struct critnib {
+	struct critnib_node *root;
+	os_mutex_t lock_index;
+};
+
 struct cache_entry;
 
 struct critnib *critnib_new(void);

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,16 +38,16 @@
 #include "vmemcache_index.h"
 #include "critnib.h"
 
-static os_mutex_t lock_index;
-
 /*
  * vmcache_index_new -- initialize vmemcache indexing structure
  */
 vmemcache_index_t *
 vmcache_index_new(void)
 {
-	util_mutex_init(&lock_index);
-	return critnib_new();
+	struct critnib *c = critnib_new();
+	if (c)
+		util_mutex_init(&c->lock_index);
+	return c;
 }
 
 /*
@@ -56,8 +56,8 @@ vmcache_index_new(void)
 void
 vmcache_index_delete(vmemcache_index_t *index)
 {
+	util_mutex_destroy(&index->lock_index);
 	critnib_delete(index);
-	util_mutex_destroy(&lock_index);
 }
 
 /*
@@ -66,10 +66,10 @@ vmcache_index_delete(vmemcache_index_t *index)
 int
 vmcache_index_insert(vmemcache_index_t *index, struct cache_entry *entry)
 {
-	util_mutex_lock(&lock_index);
+	util_mutex_lock(&index->lock_index);
 
 	if (critnib_set(index, entry)) {
-		util_mutex_unlock(&lock_index);
+		util_mutex_unlock(&index->lock_index);
 		ERR("inserting to the index failed");
 		return -1;
 	}
@@ -77,7 +77,7 @@ vmcache_index_insert(vmemcache_index_t *index, struct cache_entry *entry)
 	/* this is the first and the only one reference now (in the index) */
 	entry->value.refcount = 1;
 
-	util_mutex_unlock(&lock_index);
+	util_mutex_unlock(&index->lock_index);
 
 	return 0;
 }
@@ -113,13 +113,13 @@ vmcache_index_get(vmemcache_index_t *index, const char *key, size_t ksize,
 	e->key.ksize = ksize;
 	memcpy(e->key.key, key, ksize);
 
-	util_mutex_lock(&lock_index);
+	util_mutex_lock(&index->lock_index);
 
 	struct cache_entry *v = critnib_get(index, e);
 	if (ksize > SIZE_1K)
 		Free(e);
 	if (v == NULL) {
-		util_mutex_unlock(&lock_index);
+		util_mutex_unlock(&index->lock_index);
 		LOG(1,
 			"vmcache_index_get: cannot find an element with the given key in the index");
 		return 0;
@@ -128,7 +128,7 @@ vmcache_index_get(vmemcache_index_t *index, const char *key, size_t ksize,
 	vmemcache_entry_acquire(v);
 	*entry = v;
 
-	util_mutex_unlock(&lock_index);
+	util_mutex_unlock(&index->lock_index);
 
 	return 0;
 }
@@ -139,11 +139,11 @@ vmcache_index_get(vmemcache_index_t *index, const char *key, size_t ksize,
 int
 vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry)
 {
-	util_mutex_lock(&lock_index);
+	util_mutex_lock(&cache->index->lock_index);
 
 	struct cache_entry *v = critnib_remove(cache->index, entry);
 	if (v == NULL) {
-		util_mutex_unlock(&lock_index);
+		util_mutex_unlock(&cache->index->lock_index);
 		ERR(
 			"vmcache_index_remove: cannot find an element with the given key in the index");
 		errno = EINVAL;
@@ -152,7 +152,7 @@ vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry)
 
 	vmemcache_entry_release(cache, entry);
 
-	util_mutex_unlock(&lock_index);
+	util_mutex_unlock(&cache->index->lock_index);
 
 	return 0;
 }


### PR DESCRIPTION
The lock would be initialized and freed multiple times, causing obvious breakage if one of the caches lives longer than the other.

This also prepares for further changes to locking.