### PR TITLE
docker: add valgrind-devel package to the Fedora Docker image

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-28
+++ b/utils/docker/images/Dockerfile.fedora-28
@@ -57,6 +57,7 @@ RUN dnf update -y \
 	wget \
 	which \
 	valgrind \
+	valgrind-devel \
  && dnf clean all
 
 # Add user


### PR DESCRIPTION
... because we need also the Valgrind's header files.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/38)
<!-- Reviewable:end -->
