### PR TITLE
Index sharding

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -42,6 +42,7 @@
 #include <errno.h>
 #include <time.h>
 
+#include "out.h"
 #include "util.h"
 #include "valgrind_internal.h"
 
@@ -449,3 +450,22 @@ util_readline(FILE *fh)
 	return buffer;
 }
 #endif
+
+/*
+ * env_yesno10 -- check an env var for 1/0/y/n, fatal if invalid
+ */
+int
+env_yesno10(const char *var, int def_answer)
+{
+	const char *q = getenv(var);
+	if (!q)
+		return def_answer;
+
+	if (!strcasecmp(q, "0") || !strcasecmp(q, "n") || !strcasecmp(q, "no"))
+		return 0;
+	if (!strcasecmp(q, "1") || !strcasecmp(q, "y") || !strcasecmp(q, "yes"))
+		return 1;
+
+	FATAL("env var %s needs to be 0 or 1", var);
+	return def_answer;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -103,6 +103,7 @@ struct tm *util_localtime(const time_t *timep);
 int util_safe_strcpy(char *dst, const char *src, size_t max_length);
 void util_emit_log(const char *lib, const char *func, int order);
 char *util_readline(FILE *fh);
+int env_yesno10(const char *var, int def);
 
 #ifdef _WIN32
 char *util_toUTF8(const wchar_t *wstr);

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -40,7 +40,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "vmemcache_index.h"
 #include "vmemcache_repl.h"
 #include "sys_util.h"
 #include "vec.h"
@@ -56,11 +55,13 @@ extern "C" {
 /* type of the statistics */
 typedef unsigned long long stat_t;
 
+struct index;
+
 struct vmemcache {
 	void *addr;			/* mapping address */
 	size_t size;			/* mapping size */
 	struct heap *heap;		/* heap address */
-	vmemcache_index_t *index;	/* indexing structure */
+	struct index *index;		/* indexing structure */
 	struct repl_p repl;		/* replacement policy abstraction */
 	vmemcache_on_evict *on_evict;	/* callback on evict */
 	void *arg_evict;		/* argument for callback on evict */

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -40,38 +40,91 @@
 #include "vmemcache_index.h"
 #include "critnib.h"
 
+/* must be a power of 2 */
+#define NSHARDS 256
+
+struct index {
+	struct critnib *bucket[NSHARDS];
+};
+
+/*
+ * shard_id -- (internal) hash the key and pick a shard bucket id
+ */
+static int
+shard_id(size_t key_size, const char *key)
+{
+	/* Fowler–Noll–Vo hash */
+	uint64_t h = 0xcbf29ce484222325;
+	for (size_t i = 0; i < key_size; i++)
+		h = (h ^ (unsigned char)*key++) * 0x100000001b3;
+
+	return h & (NSHARDS - 1);
+}
+
+/*
+ * shard -- (internal) pick a shard bucket
+ */
+static struct critnib *
+shard(struct index *index, size_t key_size, const char *key)
+{
+	return index->bucket[shard_id(key_size, key)];
+}
+
 /*
  * vmcache_index_new -- initialize vmemcache indexing structure
  */
-vmemcache_index_t *
+struct index *
 vmcache_index_new(void)
 {
-	struct critnib *c = critnib_new();
-	if (c)
+	struct index *index = malloc(sizeof(struct index));
+	if (!index)
+		return NULL;
+
+	for (int i = 0; i < NSHARDS; i++) {
+		struct critnib *c = critnib_new();
+		if (!c) {
+			for (i--; i >= 0; i--) {
+				util_mutex_destroy(&index->bucket[i]->lock);
+				critnib_delete(index->bucket[i]);
+			}
+			free(index);
+
+			return NULL;
+		}
+
 		util_mutex_init(&c->lock);
-	return c;
+		index->bucket[i] = c;
+	}
+
+	return index;
 }
 
 /*
  * vmcache_index_delete -- destroy vmemcache indexing structure
  */
 void
-vmcache_index_delete(vmemcache_index_t *index)
+vmcache_index_delete(struct index *index)
 {
-	util_mutex_destroy(&index->lock);
-	critnib_delete(index);
+	for (int i = 0; i < NSHARDS; i++) {
+		util_mutex_destroy(&index->bucket[i]->lock);
+		critnib_delete(index->bucket[i]);
+	}
+
+	free(index);
 }
 
 /*
  * vmcache_index_insert -- insert data into the vmemcache indexing structure
  */
 int
-vmcache_index_insert(vmemcache_index_t *index, struct cache_entry *entry)
+vmcache_index_insert(struct index *index, struct cache_entry *entry)
 {
-	util_mutex_lock(&index->lock);
+	struct critnib *c = shard(index, entry->key.ksize, entry->key.key);
 
-	if (critnib_set(index, entry)) {
-		util_mutex_unlock(&index->lock);
+	util_mutex_lock(&c->lock);
+
+	if (critnib_set(c, entry)) {
+		util_mutex_unlock(&c->lock);
 		ERR("inserting to the index failed");
 		return -1;
 	}
@@ -79,7 +132,7 @@ vmcache_index_insert(vmemcache_index_t *index, struct cache_entry *entry)
 	/* this is the first and the only one reference now (in the index) */
 	entry->value.refcount = 1;
 
-	util_mutex_unlock(&index->lock);
+	util_mutex_unlock(&c->lock);
 
 	return 0;
 }
@@ -88,10 +141,12 @@ vmcache_index_insert(vmemcache_index_t *index, struct cache_entry *entry)
  * vmcache_index_get -- get data from the vmemcache indexing structure
  */
 int
-vmcache_index_get(vmemcache_index_t *index, const void *key, size_t ksize,
+vmcache_index_get(struct index *index, const void *key, size_t ksize,
 			struct cache_entry **entry)
 {
 #define SIZE_1K 1024
+	struct critnib *c = shard(index, ksize, key);
+
 	struct cache_entry *e;
 
 	*entry = NULL;
@@ -109,13 +164,13 @@ vmcache_index_get(vmemcache_index_t *index, const void *key, size_t ksize,
 	e->key.ksize = ksize;
 	memcpy(e->key.key, key, ksize);
 
-	util_mutex_lock(&index->lock);
+	util_mutex_lock(&c->lock);
 
-	struct cache_entry *v = critnib_get(index, e);
+	struct cache_entry *v = critnib_get(c, e);
 	if (ksize > SIZE_1K)
 		Free(e);
 	if (v == NULL) {
-		util_mutex_unlock(&index->lock);
+		util_mutex_unlock(&c->lock);
 		LOG(1,
 			"vmcache_index_get: cannot find an element with the given key in the index");
 		return 0;
@@ -124,7 +179,7 @@ vmcache_index_get(vmemcache_index_t *index, const void *key, size_t ksize,
 	vmemcache_entry_acquire(v);
 	*entry = v;
 
-	util_mutex_unlock(&index->lock);
+	util_mutex_unlock(&c->lock);
 
 	return 0;
 }
@@ -135,11 +190,14 @@ vmcache_index_get(vmemcache_index_t *index, const void *key, size_t ksize,
 int
 vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry)
 {
-	util_mutex_lock(&cache->index->lock);
+	struct critnib *c = shard(cache->index, entry->key.ksize,
+		entry->key.key);
 
-	struct cache_entry *v = critnib_remove(cache->index, entry);
+	util_mutex_lock(&c->lock);
+
+	struct cache_entry *v = critnib_remove(c, entry);
 	if (v == NULL) {
-		util_mutex_unlock(&cache->index->lock);
+		util_mutex_unlock(&c->lock);
 		ERR(
 			"vmcache_index_remove: cannot find an element with the given key in the index");
 		errno = EINVAL;
@@ -148,7 +206,7 @@ vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry)
 
 	vmemcache_entry_release(cache, entry);
 
-	util_mutex_unlock(&cache->index->lock);
+	util_mutex_unlock(&c->lock);
 
 	return 0;
 }

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -35,6 +35,7 @@
  */
 
 #include <alloca.h>
+#include <stdlib.h>
 
 #include "vmemcache.h"
 #include "vmemcache_index.h"
@@ -45,6 +46,7 @@
 
 struct index {
 	struct critnib *bucket[NSHARDS];
+	int sharding;
 };
 
 /*
@@ -67,7 +69,10 @@ shard_id(size_t key_size, const char *key)
 static struct critnib *
 shard(struct index *index, size_t key_size, const char *key)
 {
-	return index->bucket[shard_id(key_size, key)];
+	if (index->sharding)
+		return index->bucket[shard_id(key_size, key)];
+
+	return index->bucket[0];
 }
 
 /*
@@ -79,6 +84,8 @@ vmcache_index_new(void)
 	struct index *index = malloc(sizeof(struct index));
 	if (!index)
 		return NULL;
+
+	index->sharding = env_yesno10("VMEMCACHE_SHARDING", 1);
 
 	for (int i = 0; i < NSHARDS; i++) {
 		struct critnib *c = critnib_new();

--- a/src/vmemcache_index.h
+++ b/src/vmemcache_index.h
@@ -44,14 +44,13 @@
 extern "C" {
 #endif
 
-typedef struct critnib vmemcache_index_t;
 struct cache_entry;
 
-vmemcache_index_t *vmcache_index_new(void);
-void vmcache_index_delete(vmemcache_index_t *index);
-int vmcache_index_insert(vmemcache_index_t *index,
+struct index *vmcache_index_new(void);
+void vmcache_index_delete(struct index *index);
+int vmcache_index_insert(struct index *index,
 			struct cache_entry *entry);
-int vmcache_index_get(vmemcache_index_t *index, const void *key, size_t ksize,
+int vmcache_index_get(struct index *index, const void *key, size_t ksize,
 			struct cache_entry **entry);
 int vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry);
 


### PR DESCRIPTION
Should work around lock contention on a single mutex.

There's a cost to pay, though: hashing the key may take significant time.  This commit uses FNV-1a hash, but that's easy to replace.

Edit: sharding is now switchable at runtime — set ``VMEMCACHE_NO_SHARDING`` to disable.  To be replaced once/if we have proper runtime configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/45)
<!-- Reviewable:end -->
