### PR TITLE
Remove non-existing functions from libvmemcache.map and libvmemcache.h

### DIFF
--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,9 +68,6 @@ extern "C" {
 /*
  * VMEMCACHE_MAJOR_VERSION and VMEMCACHE_MINOR_VERSION provide the current
  * version of the libvmemcache API as provided by this header file.
- * Applications can verify that the version available at run-time
- * is compatible with the version used at compile-time by passing
- * these defines to vmemcache_check_version().
  */
 #define VMEMCACHE_MAJOR_VERSION 0
 #define VMEMCACHE_MINOR_VERSION 1

--- a/src/libvmemcache.map
+++ b/src/libvmemcache.map
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,8 +41,6 @@ LIBVMEMCACHE_1.0 {
 		vmemcache_evict;
 		vmemcache_callback_on_evict;
 		vmemcache_callback_on_miss;
-		vmemcache_check_version;
-		vmemcache_set_funcs;
 		vmemcache_errormsg;
 	local:
 		*;


### PR DESCRIPTION
Remove non-existing functions from libvmemcache.map and libvmemcache.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/52)
<!-- Reviewable:end -->
