### PR TITLE
Replace spin lock with mutex in heap and replacement policy

### DIFF
--- a/src/vmemcache_heap.c
+++ b/src/vmemcache_heap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,14 +34,12 @@
  * vmemcache_heap.c -- implementation of simple vmemcache linear allocator
  */
 
-#include <pthread.h>
-
 #include "vmemcache_heap.h"
 #include "vec.h"
 #include "sys_util.h"
 
 struct heap {
-	os_spinlock_t lock;
+	os_mutex_t lock;
 	size_t fragment_size;
 	VEC(, struct heap_entry) entries;
 };
@@ -63,7 +61,7 @@ vmcache_heap_create(void *addr, size_t size, size_t fragment_size)
 		return NULL;
 	}
 
-	util_spin_init(&heap->lock, PTHREAD_PROCESS_PRIVATE);
+	util_mutex_init(&heap->lock);
 	heap->fragment_size = fragment_size;
 	VEC_INIT(&heap->entries);
 	VEC_PUSH_BACK(&heap->entries, whole_heap);
@@ -80,7 +78,7 @@ vmcache_heap_destroy(struct heap *heap)
 	LOG(3, "heap %p", heap);
 
 	VEC_DELETE(&heap->entries);
-	util_spin_destroy(&heap->lock);
+	util_mutex_destroy(&heap->lock);
 	Free(heap);
 }
 
@@ -96,7 +94,7 @@ vmcache_alloc(struct heap *heap, size_t size)
 
 	size = ALIGN_UP(size, heap->fragment_size);
 
-	util_spin_lock(&heap->lock);
+	util_mutex_lock(&heap->lock);
 
 	if (VEC_POP_BACK(&heap->entries, &he) != 0)
 		goto error_no_mem;
@@ -111,7 +109,7 @@ vmcache_alloc(struct heap *heap, size_t size)
 	}
 
 error_no_mem:
-	util_spin_unlock(&heap->lock);
+	util_mutex_unlock(&heap->lock);
 
 	return he;
 }
@@ -124,9 +122,9 @@ vmcache_free(struct heap *heap, struct heap_entry he)
 {
 	LOG(3, "heap %p he.ptr %p he.size %zu", heap, he.ptr, he.size);
 
-	util_spin_lock(&heap->lock);
+	util_mutex_lock(&heap->lock);
 
 	VEC_PUSH_BACK(&heap->entries, he);
 
-	util_spin_unlock(&heap->lock);
+	util_mutex_unlock(&heap->lock);
 }

--- a/src/vmemcache_repl.c
+++ b/src/vmemcache_repl.c
@@ -35,7 +35,6 @@
  */
 
 #include <stddef.h>
-#include <pthread.h>
 
 #include "vmemcache.h"
 #include "vmemcache_repl.h"
@@ -51,7 +50,7 @@ struct repl_p_entry {
 };
 
 struct repl_p_head {
-	os_spinlock_t lock;
+	os_mutex_t lock;
 	TAILQ_HEAD(head, repl_p_entry) first;
 };
 
@@ -183,7 +182,7 @@ repl_p_lru_new(struct repl_p_head **head)
 	if (h == NULL)
 		return -1;
 
-	util_spin_init(&h->lock, PTHREAD_PROCESS_PRIVATE);
+	util_mutex_init(&h->lock);
 	TAILQ_INIT(&h->first);
 	*head = h;
 
@@ -202,7 +201,7 @@ repl_p_lru_delete(struct repl_p_head *head)
 		Free(entry);
 	}
 
-	util_spin_destroy(&head->lock);
+	util_mutex_destroy(&head->lock);
 	Free(head);
 }
 
@@ -223,12 +222,12 @@ repl_p_lru_insert(struct repl_p_head *head, void *element,
 	entry->ptr_entry = ptr_entry;
 	*(entry->ptr_entry) = entry;
 
-	util_spin_lock(&head->lock);
+	util_mutex_lock(&head->lock);
 
 	vmemcache_entry_acquire(element);
 	TAILQ_INSERT_TAIL(&head->first, entry, node);
 
-	util_spin_unlock(&head->lock);
+	util_mutex_unlock(&head->lock);
 
 	return entry;
 }
@@ -241,12 +240,12 @@ repl_p_lru_use(struct repl_p_head *head, struct repl_p_entry **ptr_entry)
 {
 	ASSERTne(ptr_entry, NULL);
 
-	util_spin_lock(&head->lock);
+	util_mutex_lock(&head->lock);
 
 	if (*ptr_entry != NULL)
 		TAILQ_MOVE_TO_TAIL(&head->first, *ptr_entry, node);
 
-	util_spin_unlock(&head->lock);
+	util_mutex_unlock(&head->lock);
 }
 
 /*
@@ -258,7 +257,7 @@ repl_p_lru_evict(struct repl_p_head *head, struct repl_p_entry **ptr_entry)
 	struct repl_p_entry *entry;
 	void *data;
 
-	util_spin_lock(&head->lock);
+	util_mutex_lock(&head->lock);
 
 	if (ptr_entry != NULL)
 		entry = *ptr_entry;
@@ -266,7 +265,7 @@ repl_p_lru_evict(struct repl_p_head *head, struct repl_p_entry **ptr_entry)
 		entry = TAILQ_FIRST(&head->first);
 
 	if (entry == NULL) {
-		util_spin_unlock(&head->lock);
+		util_mutex_unlock(&head->lock);
 		return NULL;
 	}
 
@@ -275,7 +274,7 @@ repl_p_lru_evict(struct repl_p_head *head, struct repl_p_entry **ptr_entry)
 	ASSERTne(entry->ptr_entry, NULL);
 	*(entry->ptr_entry) = NULL;
 
-	util_spin_unlock(&head->lock);
+	util_mutex_unlock(&head->lock);
 
 	data = entry->data;
 


### PR DESCRIPTION
This PR reverts PRs: #18 and #22, because we are not sure if spin locks will be really faster and if they will be actually needed, but they cause problems when tests are run under Helgrind right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/53)
<!-- Reviewable:end -->
