### PR TITLE
test: make it possible to change the pool's directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,13 +32,21 @@
 set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/test
 	CACHE STRING "working directory for tests")
 
+set(TEST_POOL_DIR ${TEST_DIR}
+	CACHE STRING "directory for vmemcache memory pool used for tests")
+
 set(DEVICE_DAX_PATHS "" CACHE STRING
 	"for tests that require raw dax devices without a file system. Some tests might require two DAX devices.
 	Example: '/dev/dax1.0 /dev/dax2.0'")
 
+if("${TEST_POOL_DIR}" STREQUAL "")
+	set(TEST_POOL_DIR ${TEST_DIR})
+endif()
+
 set(GLOBAL_TEST_ARGS
 	-DPARENT_DIR=${TEST_DIR}/
-	-DDEVICE_DAX_PATHS=${DEVICE_DAX_PATHS})
+	-DDEVICE_DAX_PATHS=${DEVICE_DAX_PATHS}
+	-DTEST_POOL_DIR=${TEST_POOL_DIR})
 
 # convert the DEVICE_DAX_PATHS list to the array
 if(DEVICE_DAX_PATHS)

--- a/tests/test-basic.cmake
+++ b/tests/test-basic.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,6 +33,6 @@ include(${SRC_DIR}/helpers.cmake)
 
 setup()
 
-execute(0 ${TEST_DIR}/vmemcache_test_basic ${TEST_DIR})
+execute(0 ${TEST_DIR}/vmemcache_test_basic ${TEST_POOL_DIR})
 
 cleanup()

--- a/tests/test-bench-mt.cmake
+++ b/tests/test-bench-mt.cmake
@@ -33,6 +33,6 @@ include(${SRC_DIR}/helpers.cmake)
 
 setup()
 
-execute(0 ${TEST_DIR}/../benchmarks/bench_micro "${TEST_DIR}")
+execute(0 ${TEST_DIR}/../benchmarks/bench_micro "${TEST_POOL_DIR}")
 
 cleanup()

--- a/tests/test-mt.cmake
+++ b/tests/test-mt.cmake
@@ -43,6 +43,6 @@ else()
 	set(N_OPS 10000)
 endif()
 
-execute(0 ${TEST_DIR}/vmemcache_test_mt ${TEST_DIR} ${N_THREADS} ${N_OPS})
+execute(0 ${TEST_DIR}/vmemcache_test_mt ${TEST_POOL_DIR} ${N_THREADS} ${N_OPS})
 
 cleanup()


### PR DESCRIPTION
This change is just in order to make it possible
to easily change the pool's directory for tests,
for example to DAX device. TEST_DIR cannot be used for that,
because CMake creates new subdirectories in TEST_DIR.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/66)
<!-- Reviewable:end -->
