### PR TITLE
clean up types and includes of headers

### DIFF
--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -41,7 +41,6 @@
 #include <stddef.h>
 
 #include "libvmemcache.h"
-#include "sys_util.h"
 #include "vec.h"
 
 #ifdef __cplusplus

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -40,7 +40,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "vmemcache_repl.h"
+#include "libvmemcache.h"
 #include "sys_util.h"
 #include "vec.h"
 
@@ -56,13 +56,14 @@ extern "C" {
 typedef unsigned long long stat_t;
 
 struct index;
+struct repl_p;
 
 struct vmemcache {
 	void *addr;			/* mapping address */
 	size_t size;			/* mapping size */
 	struct heap *heap;		/* heap address */
 	struct index *index;		/* indexing structure */
-	struct repl_p repl;		/* replacement policy abstraction */
+	struct repl_p *repl;		/* replacement policy abstraction */
 	vmemcache_on_evict *on_evict;	/* callback on evict */
 	void *arg_evict;		/* argument for callback on evict */
 	vmemcache_on_miss *on_miss;	/* callback on miss */

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -36,10 +36,12 @@
 
 #include <alloca.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include "vmemcache.h"
 #include "vmemcache_index.h"
 #include "critnib.h"
+#include "sys_util.h"
 
 /* must be a power of 2 */
 #define NSHARDS 256

--- a/src/vmemcache_repl.c
+++ b/src/vmemcache_repl.c
@@ -107,14 +107,23 @@ static const struct repl_p_ops repl_p_ops[VMEMCACHE_REPLACEMENT_NUM] = {
 };
 
 /*
- * repl_p_init -- initialize the replacement policy structure
+ * repl_p_init -- allocate and initialize the replacement policy structure
  */
-int
-repl_p_init(struct repl_p *repl_p, enum vmemcache_replacement_policy rp)
+struct repl_p *
+repl_p_init(enum vmemcache_replacement_policy rp)
 {
+	struct repl_p *repl_p = Malloc(sizeof(struct repl_p));
+	if (repl_p == NULL)
+		return NULL;
+
 	repl_p->ops = &repl_p_ops[rp];
 
-	return repl_p->ops->repl_p_new(&repl_p->head);
+	if (repl_p->ops->repl_p_new(&repl_p->head)) {
+		Free(repl_p);
+		return NULL;
+	}
+
+	return repl_p;
 }
 
 /*
@@ -123,7 +132,10 @@ repl_p_init(struct repl_p *repl_p, enum vmemcache_replacement_policy rp)
 void
 repl_p_destroy(struct repl_p *repl_p)
 {
+	ASSERTne(repl_p, NULL);
+
 	repl_p->ops->repl_p_delete(repl_p->head);
+	Free(repl_p);
 }
 
 /*

--- a/src/vmemcache_repl.h
+++ b/src/vmemcache_repl.h
@@ -76,7 +76,7 @@ struct repl_p {
 	struct repl_p_head *head;
 };
 
-int repl_p_init(struct repl_p *repl_p, enum vmemcache_replacement_policy rp);
+struct repl_p *repl_p_init(enum vmemcache_replacement_policy rp);
 void repl_p_destroy(struct repl_p *repl_p);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Replace `struct repl_p repl` with `struct repl_p *repl`
in the `struct vmemcache` in preparation to add a 'free' callback
to vmcache_index_delete() and critnib_delete().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/76)
<!-- Reviewable:end -->
