### PR TITLE
accept missing *vsize

### DIFF
--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -396,7 +396,8 @@ vmemcache_get(VMEMcache *cache, const void *key, size_t ksize, void *vbuf,
 	cache->repl.ops->repl_p_use(cache->repl.head, &entry->value.p_entry);
 
 	size_t read = vmemcache_populate_value(vbuf, vbufsize, offset, entry);
-	*vsize = entry->value.vsize;
+	if (vsize)
+		*vsize = entry->value.vsize;
 
 	vmemcache_entry_release(cache, entry);
 


### PR DESCRIPTION
It's not the primary result of vmemcache_get(), thus it's reasonable for the user to omit it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/80)
<!-- Reviewable:end -->
