### PR TITLE
Fix memory leaks in vmemcache_delete

### DIFF
--- a/benchmarks/bench_micro.c
+++ b/benchmarks/bench_micro.c
@@ -94,10 +94,6 @@ bench_init(const char *path, size_t max_size, size_t fragment_size,
 static void
 bench_fini(VMEMcache *cache)
 {
-	/* free all the memory */
-	while (vmemcache_evict(cache, NULL, 0) == 0)
-		;
-
 	vmemcache_delete(cache);
 }
 

--- a/src/critnib.c
+++ b/src/critnib.c
@@ -114,14 +114,17 @@ critnib_new(void)
  * delete_node -- (internal) recursively free a subtree
  */
 static void
-delete_node(struct critnib_node *n)
+delete_node(struct critnib_node *n, delete_entry_t del)
 {
 	if (!n)
 		return;
-	if (is_leaf(n))
+	if (is_leaf(n)) {
+		if (del)
+			del(to_leaf(n)->value);
 		return Free(to_leaf(n));
+	}
 	for (int i = 0; i < SLNODES; i++)
-		delete_node(n->child[i]);
+		delete_node(n->child[i], del);
 	Free(n);
 }
 
@@ -129,9 +132,9 @@ delete_node(struct critnib_node *n)
  * critnib_delete -- free a hashmap
  */
 void
-critnib_delete(struct critnib *c)
+critnib_delete(struct critnib *c, delete_entry_t del)
 {
-	delete_node(c->root);
+	delete_node(c->root, del);
 	Free(c);
 }
 

--- a/src/critnib.h
+++ b/src/critnib.h
@@ -45,7 +45,7 @@ struct critnib {
 struct cache_entry;
 
 struct critnib *critnib_new(void);
-void critnib_delete(struct critnib *c);
+void critnib_delete(struct critnib *c, delete_entry_t del);
 int critnib_set(struct critnib *c, struct cache_entry *e);
 void *critnib_get(struct critnib *c, const struct cache_entry *e);
 void *critnib_remove(struct critnib *c, const struct cache_entry *e);

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -162,7 +162,7 @@ vmemcache_newU(const char *dir, size_t max_size, size_t fragment_size,
 	return cache;
 
 error_destroy_index:
-	vmcache_index_delete(cache->index);
+	vmcache_index_delete(cache->index, vmemcache_delete_entry_cb);
 error_destroy_heap:
 	vmcache_heap_destroy(cache->heap);
 error_unmap:
@@ -173,13 +173,24 @@ error_free_cache:
 }
 
 /*
+ * vmemcache_delete_entry_cb -- callback deleting a vmemcache entry
+ *                              for vmemcache_delete()
+ */
+void
+vmemcache_delete_entry_cb(struct cache_entry *entry)
+{
+	VEC_DELETE(&entry->value.fragments);
+	Free(entry);
+}
+
+/*
  * vmemcache_delete -- destroy a vmemcache
  */
 void
 vmemcache_delete(VMEMcache *cache)
 {
 	repl_p_destroy(cache->repl);
-	vmcache_index_delete(cache->index);
+	vmcache_index_delete(cache->index, vmemcache_delete_entry_cb);
 	vmcache_heap_destroy(cache->heap);
 	util_unmap(cache->addr, cache->size);
 	Free(cache);

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -91,6 +91,12 @@ struct cache_entry {
 	} key;
 };
 
+/* type of callback deleting a cache entry */
+typedef void (*delete_entry_t)(struct cache_entry *entry);
+
+/* callback deleting a cache entry (of the above type 'delete_entry_t') */
+void vmemcache_delete_entry_cb(struct cache_entry *entry);
+
 void vmemcache_entry_acquire(struct cache_entry *entry);
 void vmemcache_entry_release(VMEMcache *cache, struct cache_entry *entry);
 

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -94,7 +94,7 @@ vmcache_index_new(void)
 		if (!c) {
 			for (i--; i >= 0; i--) {
 				util_mutex_destroy(&index->bucket[i]->lock);
-				critnib_delete(index->bucket[i]);
+				critnib_delete(index->bucket[i], NULL);
 			}
 			free(index);
 
@@ -116,7 +116,7 @@ vmcache_index_delete(struct index *index, delete_entry_t del_entry)
 {
 	for (int i = 0; i < NSHARDS; i++) {
 		util_mutex_destroy(&index->bucket[i]->lock);
-		critnib_delete(index->bucket[i]);
+		critnib_delete(index->bucket[i], del_entry);
 	}
 
 	free(index);

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -112,7 +112,7 @@ vmcache_index_new(void)
  * vmcache_index_delete -- destroy vmemcache indexing structure
  */
 void
-vmcache_index_delete(struct index *index)
+vmcache_index_delete(struct index *index, delete_entry_t del_entry)
 {
 	for (int i = 0; i < NSHARDS; i++) {
 		util_mutex_destroy(&index->bucket[i]->lock);

--- a/src/vmemcache_index.h
+++ b/src/vmemcache_index.h
@@ -47,7 +47,7 @@ extern "C" {
 struct cache_entry;
 
 struct index *vmcache_index_new(void);
-void vmcache_index_delete(struct index *index);
+void vmcache_index_delete(struct index *index, delete_entry_t del_entry);
 int vmcache_index_insert(struct index *index,
 			struct cache_entry *entry);
 int vmcache_index_get(struct index *index, const void *key, size_t ksize,

--- a/tests/vmemcache_test_mt.c
+++ b/tests/vmemcache_test_mt.c
@@ -379,7 +379,6 @@ exit_free_buffs:
 	free(buffs);
 
 exit_delete:
-	free_cache(cache);
 	vmemcache_delete(cache);
 
 	return ret;


### PR DESCRIPTION
vmemcache_delete() does not free all allocated cache entries yet. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/85)
<!-- Reviewable:end -->
