### PR TITLE
simul: some pretty-printing of parameter values

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -298,6 +298,11 @@ static void run_bench()
 static void
 print_units(uint64_t x)
 {
+	if (x == -1ULL) {
+		printf("∞");
+		return;
+	}
+
 	const char *units[] = { "", "K", "M", "G", "T", "P", "E" };
 	int u = 0;
 

--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -295,6 +295,20 @@ static void run_bench()
 		total / 1000, total % 1000);
 }
 
+static void
+print_units(uint64_t x)
+{
+	const char *units[] = { "", "K", "M", "G", "T", "P", "E" };
+	int u = 0;
+
+	while (x && !(x % 1024)) {
+		u++;
+		x /= 1024;
+	}
+
+	printf("%lu%s", x, units[u]);
+}
+
 int
 main(int argc, const char **argv)
 {
@@ -321,7 +335,7 @@ main(int argc, const char **argv)
 			else
 				printf("enum out of range: %lu", *p->var);
 		} else
-			printf("%lu", *p->var);
+			print_units(*p->var);
 		printf("\n");
 	}
 


### PR DESCRIPTION
Most of the sizes used come in large units, so let's make them human-readable.

We also use -1ULL as "unlimited", "18446744073709551615" isn't exactly recognizable as a special number at a glance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/96)
<!-- Reviewable:end -->
