### PR TITLE
add Average Cache pseudo-Time (ACT) statistic

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -111,7 +111,8 @@ static const char *stat_str[VMEMCACHE_STATS_NUM] = {
 	"evicts",
 	"cache entries",
 	"DRAM size used",
-	"pool size used"
+	"pool size used",
+	"ACT"
 };
 
 /*
@@ -306,6 +307,7 @@ print_stats(VMEMcache *cache)
 	get_stat(cache, stat_vals, VMEMCACHE_STAT_ENTRIES);
 	get_stat(cache, stat_vals, VMEMCACHE_STAT_DRAM_SIZE_USED);
 	get_stat(cache, stat_vals, VMEMCACHE_STAT_POOL_SIZE_USED);
+	get_stat(cache, stat_vals, VMEMCACHE_STAT_ACT);
 
 	printf("\nStatistics:\n");
 	for (int i = 0; i < VMEMCACHE_STATS_NUM; i++)

--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -96,7 +96,15 @@ enum vmemcache_statistic {
 	VMEMCACHE_STAT_ENTRIES,		/* current number of cache entries */
 	VMEMCACHE_STAT_DRAM_SIZE_USED,	/* current size of DRAM used for keys */
 	VMEMCACHE_STAT_POOL_SIZE_USED,	/* current size of memory pool */
-					/*    used for values */
+					/*    used for values          */
+	VMEMCACHE_STAT_ACT,		/* Average Cache pseudo-Time (ACT) - */
+					/*  - average pseudo-time            */
+					/*    (number of puts and gets)      */
+					/*    spent by evicted entries       */
+					/*    in the cache.                  */
+					/*    If there were no evicts,       */
+					/*    ACT equals 0.                  */
+
 	VMEMCACHE_STATS_NUM		/* total number of statistics */
 };
 

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -62,7 +62,8 @@ static const char *stat_str[VMEMCACHE_STATS_NUM] = {
 	"EVICTs",
 	"CACHE_ENTRIES",
 	"DRAM_SIZE_USED",
-	"POOL_SIZE_USED"
+	"POOL_SIZE_USED",
+	"ACT"
 };
 
 /* context of callbacks */
@@ -161,6 +162,15 @@ verify_stats(VMEMcache *cache, stat_t put, stat_t get, stat_t hit, stat_t miss,
 		UT_FATAL(
 			"vmemcache_get_stat: wrong statistic's (%s) value: %llu (should be %llu)",
 			stat_str[VMEMCACHE_STAT_POOL_SIZE_USED], stat, pool);
+
+	ret = vmemcache_get_stat(cache, VMEMCACHE_STAT_ACT,
+			&stat, sizeof(stat));
+	if (ret == -1)
+		UT_FATAL("vmemcache_get_stat: %s", vmemcache_errormsg());
+	if (stat == 0)
+		UT_FATAL(
+			"vmemcache_get_stat: wrong statistic's (%s) value: %llu (should be > 0)",
+			stat_str[VMEMCACHE_STAT_ACT], stat);
 
 	ret = vmemcache_get_stat(cache, VMEMCACHE_STATS_NUM,
 					&stat, sizeof(stat));


### PR DESCRIPTION
Add a new statistic: Average Cache pseudo-Time (ACT)
- average pseudo-time (number of puts and gets)
spent by evicted entries in the cache.
If there were no evicts, ACT equals 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/103)
<!-- Reviewable:end -->
