### PR TITLE
API: add vmemcache_config_set()

### DIFF
--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -100,6 +100,12 @@ enum vmemcache_statistic {
 	VMEMCACHE_STATS_NUM		/* total number of statistics */
 };
 
+enum vmemcache_bench_cfg {
+	/* these will corrupt the data, good only for benchmarking */
+	VMEMCACHE_BENCH_INDEX_ONLY,	/* disable anything but indexing */
+	VMEMCACHE_BENCH_NO_MEMCPY,	/* alloc but don't copy data */
+};
+
 typedef void vmemcache_on_evict(VMEMcache *cache,
 	const void *key, size_t key_size, void *arg);
 typedef int vmemcache_on_miss(VMEMcache *cache,
@@ -149,6 +155,10 @@ const char *vmemcache_errormsg(void);
 const char *vmemcache_errormsgU(void);
 const wchar_t *vmemcache_errormsgW(void);
 #endif
+
+/* UNSTABLE INTEFACE -- DO NOT USE! */
+void vmemcache_bench_set(VMEMcache *cache, enum vmemcache_bench_cfg cfg,
+	size_t val);
 
 #ifdef __cplusplus
 }

--- a/src/libvmemcache.map
+++ b/src/libvmemcache.map
@@ -42,6 +42,7 @@ LIBVMEMCACHE_1.0 {
 		vmemcache_callback_on_evict;
 		vmemcache_callback_on_miss;
 		vmemcache_get_stat;
+		vmemcache_bench_set;
 		vmemcache_errormsg;
 	local:
 		*;

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -564,6 +564,25 @@ vmemcache_get_stat(VMEMcache *cache, enum vmemcache_statistic stat,
 	return 0;
 }
 
+/*
+ * vmemcache_bench_set -- alter a benchmark parameter
+ */
+void
+vmemcache_bench_set(VMEMcache *cache, enum vmemcache_bench_cfg cfg,
+				size_t val)
+{
+	switch (cfg) {
+	case VMEMCACHE_BENCH_INDEX_ONLY:
+		cache->index_only = !!val;
+		break;
+	case VMEMCACHE_BENCH_NO_MEMCPY:
+		cache->no_memcpy = !!val;
+		break;
+	default:
+		ERR("invalid config parameter: %u", cfg);
+	}
+}
+
 #ifndef _WIN32
 /*
  * vmemcache_new -- create a vmemcache

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -67,6 +67,8 @@ struct vmemcache {
 	void *arg_evict;		/* argument for callback on evict */
 	vmemcache_on_miss *on_miss;	/* callback on miss */
 	void *arg_miss;			/* argument for callback on miss */
+	unsigned index_only:1;		/* bench: disable allocations */
+	unsigned no_memcpy:1;		/* bench: don't copy actual data */
 
 	/* statistics */
 	stat_t put_count;		/* total number of puts */


### PR DESCRIPTION
Turns out our benchmarks are not very realistic — the cache looks completely different after minutes of work than from an empty start, and what we're interested in is how it'd be after a month of use.  Thus, an env var or similar is no good — the benchmark will need to simulate ʟᴏᴛꜱ of operations, and only then enable back full functionality that's supposed to be measured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/107)
<!-- Reviewable:end -->
