### PR TITLE
Fix compilation with glibc headers older than 2.25.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ endif()
 
 set(CMAKE_C_STANDARD 99)
 
+include(CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(getentropy unistd.h HAVE_GETENTROPY)
+
 # Checks whether flag is supported by current C compiler and appends
 # it to the relevant cmake variable.
 # 1st argument is a flag

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -58,3 +58,6 @@ target_include_directories(bench_simul PRIVATE
 
 target_link_libraries(bench_simul PRIVATE vmemcache)
 target_link_libraries(bench_simul PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+if (HAVE_GETENTROPY)
+	target_compile_definitions(bench_simul PRIVATE HAVE_GETENTROPY)
+endif()

--- a/benchmarks/rand.c
+++ b/benchmarks/rand.c
@@ -101,8 +101,10 @@ void
 randomize_r(rng_t *state, uint64_t seed)
 {
 	if (!seed) {
+#ifdef HAVE_GETENTROPY
 		if (!getentropy(state, sizeof(rng_t)))
 			return; /* nofail, but ENOSYS on kernel < 3.16 */
+#endif
 		seed = (uint64_t)getpid();
 	}
 


### PR DESCRIPTION
Would fail on Ubuntu 16.04, Debian Stretch, openSuSE 14, any CentOS.

The fallback is very weak but we don't need good randomness for seeding benchmarks.  Beware when taking this code for other projects, though!  Or just wait till old musty distro releases get EOLed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/119)
<!-- Reviewable:end -->
