### PR TITLE
Fix a crash with _get(vbuf=null).

### DIFF
--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -296,6 +296,9 @@ static size_t
 vmemcache_populate_value(void *vbuf, size_t vbufsize, size_t offset,
 				struct cache_entry *entry)
 {
+	if (!vbuf)
+		return 0;
+
 	struct heap_entry he;
 	size_t copied = 0;
 	size_t left_to_copy = entry->value.vsize;

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -500,6 +500,9 @@ test_evict(const char *dir,
 		UT_FATAL("vmemcache_get: wrong value: %s (should be %s)",
 			ctx.vbuf, data[2].key);
 
+	/* TEST #6 - null output arguments */
+	vmemcache_get(cache, data[2].key, KSIZE, NULL, VSIZE, 0, NULL);
+
 	/* free all the memory */
 	while (vmemcache_evict(cache, NULL, 0) == 0)
 		;
@@ -507,8 +510,8 @@ test_evict(const char *dir,
 	/* check statistics */
 	verify_stats(cache,
 			DNUM, /* put */
-			2 - ctx.miss_count + ctx.evict_count, /* get */
-			2 - 2 * ctx.miss_count + ctx.evict_count, /* hit */
+			3 - ctx.miss_count + ctx.evict_count, /* get */
+			3 - 2 * ctx.miss_count + ctx.evict_count, /* hit */
 			ctx.miss_count, ctx.evict_count, 0, 0, 0);
 
 	vmemcache_delete(cache);


### PR DESCRIPTION
That's not the intended way to use the API, but there are uses for not caring about the contents yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/120)
<!-- Reviewable:end -->
