### PR TITLE
bench: use vmemcache_errormsg() instead of strerror()

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -337,7 +337,7 @@ static void *worker(void *arg)
 			if (vmemcache_put(cache, key, key_size, lotta_zeroes,
 				max_size) && errno != EEXIST) {
 				UT_FATAL("vmemcache_put failed: %s",
-					strerror(errno));
+						vmemcache_errormsg());
 			}
 
 			if (lat)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/126)
<!-- Reviewable:end -->
