### PR TITLE
evict: do not error out if the element is being evicted just now

### DIFF
--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -475,10 +475,12 @@ vmemcache_evict(VMEMcache *cache, const void *key, size_t ksize)
 
 		if (!__sync_bool_compare_and_swap(&entry->value.evicting,
 							0, 1)) {
-			ERR(
-				"vmemcache_evict: the element with the given key is being evicted just now!");
-			errno = EBUSY;
-			goto exit_release;
+			/*
+			 * Element with the given key is being evicted just now.
+			 * Release the reference from vmcache_index_get().
+			 */
+			vmemcache_entry_release(cache, entry);
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Do not error out if the element with the given key
is being evicted just now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/127)
<!-- Reviewable:end -->
