### PR TITLE
do not handle failure of vmcache_index_remove() in vmemcache_evict()

### DIFF
--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -498,10 +498,7 @@ vmemcache_evict(VMEMcache *cache, const void *key, size_t ksize)
 	/* release the element */
 	vmemcache_entry_release(cache, entry);
 
-	if (vmcache_index_remove(cache, entry)) {
-		LOG(1, "removing from the index failed");
-		goto exit_release;
-	}
+	vmcache_index_remove(cache, entry);
 
 	return 0;
 


### PR DESCRIPTION
vmcache_index_remove() can fail only if there is no element
with the given key in the index, what is the desired state,
so there is no need to error out in such case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/131)
<!-- Reviewable:end -->
