### PR TITLE
Guarantee that an on_miss callback fulfills a failed get request.

### DIFF
--- a/doc/vmemcache.md
+++ b/doc/vmemcache.md
@@ -193,13 +193,9 @@ Obtains a piece of statistics about the cache. The *stat* may be:
  + **VMEMCACHE_STAT_GET**
 	count of gets
  + **VMEMCACHE_STAT_HIT**
-	count of gets that received data from the cache
-	FIXME - broken
+	count of gets that were served from the cache
  + **VMEMCACHE_STAT_MISS**
 	count of gets that were not present in the cache
-	FIXME - broken
-	PROPOSED: this number might be distinct from gets - hits, because of
-	callbacks producing data?
  + **VMEMCACHE_STAT_EVICT**
 	count of evictions
  + **VMEMCACHE_STAT_ENTRIES**

--- a/doc/vmemcache.md
+++ b/doc/vmemcache.md
@@ -169,14 +169,13 @@ meantime.
 
 
 ```
-int vmemcache_on_miss(VMEMcache *cache,
+void vmemcache_on_miss(VMEMcache *cache,
 	const void *key, size_t key_size, void *arg);
 ```
 
 Called when a *get* query fails, to provide an opportunity to insert the
-missing key. If the callback returns zero, upon return the query will
-be retried (just once - no more calls if it fails again). Note that it's
-possible that the entry will be evicted between the insert and get.
+missing key. If the callback calls *put* for that specific key, the *get*
+will return its value, even if it did not fit into the cache.
 
 
 ##### Misc #####

--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -110,12 +110,7 @@ enum vmemcache_bench_cfg {
 typedef void vmemcache_on_evict(VMEMcache *cache,
 	const void *key, size_t key_size, void *arg);
 
-/*
- * The return value of vmemcache_on_miss callback means:
- *  == 0 - it succeeded to insert the missing key into the cache
- *  != 0 - it failed to insert the missing key into the cache
- */
-typedef int vmemcache_on_miss(VMEMcache *cache,
+typedef void vmemcache_on_miss(VMEMcache *cache,
 	const void *key, size_t key_size, void *arg);
 
 #ifndef _WIN32

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -406,6 +406,8 @@ vmemcache_get(VMEMcache *cache, const void *key, size_t ksize, void *vbuf,
 	struct cache_entry *entry;
 	size_t read = 0;
 
+	util_fetch_and_add64(&cache->get_count, 1);
+
 	int ret = vmcache_index_get(cache->index, key, ksize, &entry);
 	if (ret < 0)
 		return -1;
@@ -424,8 +426,6 @@ vmemcache_get(VMEMcache *cache, const void *key, size_t ksize, void *vbuf,
 		if (entry == NULL)
 			return 0;
 	}
-
-	util_fetch_and_add64(&cache->get_count, 1);
 
 	if (cache->index_only)
 		goto get_index;

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -50,6 +50,19 @@
 #include "valgrind_internal.h"
 
 /*
+ * Arguments to currently running get request, during a callback.
+ */
+static __thread struct {
+	const char *key;
+	size_t ksize;
+	void *vbuf;
+	size_t vbufsize;
+	size_t offset;
+	size_t *vsize;
+} get_req = { 0 };
+
+
+/*
  * vmemcache_newU -- (internal) create a vmemcache
  */
 #ifndef _WIN32
@@ -218,6 +231,28 @@ vmemcache_populate_fragments(struct cache_entry *entry,
 	entry->value.vsize = value_size;
 }
 
+static void
+vmemcache_put_satisfy_get(const void *key, size_t ksize,
+		const void *value, size_t value_size)
+{
+	if (get_req.ksize != ksize || memcmp(get_req.key, key, ksize))
+		return; /* not our key */
+
+	get_req.key = NULL; /* mark request as satisfied */
+
+	if (get_req.offset >= value_size) {
+		get_req.vbufsize = 0;
+	} else {
+		if (get_req.vbufsize > value_size - get_req.offset)
+			get_req.vbufsize = value_size - get_req.offset;
+		if (get_req.vbuf)
+			memcpy(get_req.vbuf, value, get_req.vbufsize);
+	}
+
+	if (get_req.vsize)
+		*get_req.vsize = value_size;
+}
+
 /*
  * vmemcache_put -- put an element into the vmemcache
  */
@@ -225,6 +260,9 @@ int
 vmemcache_put(VMEMcache *cache, const void *key, size_t ksize,
 				const void *value, size_t value_size)
 {
+	if (get_req.key)
+		vmemcache_put_satisfy_get(key, ksize, value, value_size);
+
 	if (value_size > cache->size) {
 		ERR("value larger than entire cache");
 		errno = ENOSPC;
@@ -415,16 +453,22 @@ vmemcache_get(VMEMcache *cache, const void *key, size_t ksize, void *vbuf,
 	if (entry == NULL) { /* cache miss */
 		util_fetch_and_add64(&cache->miss_count, 1);
 
-		if (cache->on_miss == NULL ||
-		    (*cache->on_miss)(cache, key, ksize, cache->arg_miss))
-			return 0;
+		if (cache->on_miss) {
+			get_req.key = key;
+			get_req.ksize = ksize;
+			get_req.vbuf = vbuf;
+			get_req.vbufsize = vbufsize;
+			get_req.offset = offset;
+			get_req.vsize = vsize;
 
-		ret = vmcache_index_get(cache->index, key, ksize, &entry);
-		if (ret < 0)
-			return -1;
+			(*cache->on_miss)(cache, key, ksize, cache->arg_miss);
 
-		if (entry == NULL)
-			return 0;
+			if (!get_req.key)
+				return (ssize_t)get_req.vbufsize;
+			get_req.key = NULL;
+		}
+
+		return 0;
 	}
 
 	if (cache->index_only)

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -39,6 +39,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <errno.h>
@@ -54,6 +55,11 @@
 	fprintf(stderr, __VA_ARGS__);\
 	fprintf(stderr, "\n");\
 	abort();\
+} while (/*CONSTCOND*/0)
+
+#define UT_ASSERTeq(x, y) do if ((x) != (y)) {\
+	UT_FATAL("ASSERT FAILED : " #x " (%zu) ≠ %zu",\
+		(uint64_t)(x), (uint64_t)(y));\
 } while (/*CONSTCOND*/0)
 
 #define UT_ASSERTin(x, min, max) do if ((x) < (min) || (x) > (max)) {\

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -384,7 +384,7 @@ on_evict_test_evict_cb(VMEMcache *cache, const void *key, size_t key_size,
 /*
  * on_miss_test_evict_cb -- (internal) 'on miss' callback for test_evict
  */
-static int
+static void
 on_miss_test_evict_cb(VMEMcache *cache, const void *key, size_t key_size,
 		void *arg)
 {
@@ -396,8 +396,6 @@ on_miss_test_evict_cb(VMEMcache *cache, const void *key, size_t key_size,
 
 	memcpy(ctx->vbuf, key, size);
 	ctx->vsize = size;
-
-	return 1;
 }
 
 /*

--- a/tests/vmemcache_test_mt.c
+++ b/tests/vmemcache_test_mt.c
@@ -279,7 +279,7 @@ run_test_get_put(VMEMcache *cache, unsigned n_threads, os_thread_t *threads,
 /*
  * on_miss_cb -- (internal) 'on miss' callback for run_test_get_on_miss
  */
-static int
+static void
 on_miss_cb(VMEMcache *cache, const void *key, size_t key_size, void *arg)
 {
 	struct context *ctx = arg;
@@ -294,8 +294,6 @@ on_miss_cb(VMEMcache *cache, const void *key, size_t key_size, void *arg)
 				ctx->buffs[n % ctx->nbuffs].size);
 	if (ret && errno != EEXIST)
 		UT_FATAL("ERROR: vmemcache_put: %s", vmemcache_errormsg());
-
-	return ret;
 }
 
 /*


### PR DESCRIPTION
There are rare cases when the value the user provided wasn't delivered.  Let's not have nasty surprises — this kind of failures is very difficult to test against, and workarounds disrupt the workflow.

As a bonus, this simplifies the on_miss code path and makes it faster.

It affects the stats (wrt #124) — I fixed the non-controversial case of no on_miss; we still need to agree what to return when the callback exists and fails or succeeds.

Fixes #122.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/137)
<!-- Reviewable:end -->
