### PR TITLE
API: make failed get return -1, ENOENT

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -385,7 +385,7 @@ run_ops(uint64_t ops, rng_t *rng, uint64_t *lat, void *get_buffer)
 			opt = getticks();
 
 		if (vmemcache_get(cache, key, key_size, get_buffer, get_size, 0,
-			NULL) <= 0) {
+			NULL) < 0) {
 
 			uint64_t size = min_size
 				+ (uint64_t)((double)(max_size - min_size + 1)

--- a/doc/vmemcache.md
+++ b/doc/vmemcache.md
@@ -126,10 +126,9 @@ for *vbufsize* bytes, optionally skipping *offset* bytes at the start.
 No matter if the copy was truncated or not, its true size is stored into
 *vsize*; *vsize* remains unmodified if the key was not found.
 
-Return value is -1 on error, 0 if the key was not found, or number of bytes
-successfully copied otherwise. Note that 0 may be legitimately returned
-even if the key was found (reading past end, zero-sized value, etc) -
-check *vsize* to tell that apart.
+Return value is number of bytes successfully copied, or -1 on error.
+In particular, if there's no entry for the given *key* in the cache,
+the errno will be ENOENT.
 
 
 ```
@@ -224,7 +223,7 @@ be:
  + **EEXIST**
 	(put) entry for that key already exists
  + **ENOENT**
-	(evict) no entry for that key
+	(evict, get) no entry for that key
  + **ESRCH**
 	(evict) couldn't find an evictable entry
  + **ENOSPC**

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -455,7 +455,12 @@ vmemcache_get(VMEMcache *cache, const void *key, size_t ksize, void *vbuf,
 			get_req.key = NULL;
 		}
 
-		return 0;
+		errno = ENOENT;
+		/*
+		 * Needed for errormsg but wastes 13% of time.  FIXME.
+		 * ERR("cache entry not found");
+		 */
+		return -1;
 	}
 
 	if (cache->index_only)

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -350,10 +350,10 @@ test_put_get_evict(const char *dir,
 	if (ret == -1)
 		UT_FATAL("vmemcache_evict: %s", vmemcache_errormsg());
 
-	/* getting the evicted element should return 0 (no such element) */
+	/* getting the evicted element should return -1 (no such element) */
 	ret = vmemcache_get(cache, key, key_size, vbuf, vbufsize, 0, &vsize);
-	if (ret != 0)
-		UT_FATAL("vmemcache_get did not return 0 (no such element)");
+	if (ret != -1 || errno != ENOENT)
+		UT_FATAL("vmemcache_get did not return -1 (no such element)");
 
 	vmemcache_delete(cache);
 }
@@ -515,8 +515,12 @@ test_evict(const char *dir,
 	/* stats: get:1 miss:1 */
 	ret = vmemcache_get(cache, data[2].key, KSIZE, vbuf, VSIZE,
 			0, &vsize);
-	if (ret == -1)
-		UT_FATAL("vmemcache_get");
+
+	if (ret != -1)
+		UT_FATAL("vmemcache_get succeeded when it shouldn't");
+
+	if (errno != ENOENT)
+		UT_FATAL("vmemcache_get: errno %d should be ENOENT", errno);
 
 	/* check if the 'on_miss' callback got key #2 */
 	if (strncmp(ctx.vbuf, data[2].key, ctx.vsize))

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -518,16 +518,6 @@ test_evict(const char *dir,
 	if (ret == -1)
 		UT_FATAL("vmemcache_get");
 
-	if (ret != 0)
-		UT_FATAL(
-			"vmemcache_get: wrong return value: %zi (should be %i)",
-			ret, 0);
-
-	if (vsize != VSIZE)
-		UT_FATAL(
-			"vmemcache_get: wrong size of value: %zi (should be %i)",
-			vsize, VSIZE);
-
 	/* check if the 'on_miss' callback got key #2 */
 	if (strncmp(ctx.vbuf, data[2].key, ctx.vsize))
 		UT_FATAL("vmemcache_get: wrong value: %s (should be %s)",


### PR DESCRIPTION
The return value of 0 was too overloaded: it meant reading past vsize, vsize=0 — and non-existing key.  So let's make the latter return -1 (an error) with errno of ENOENT.

[This includes #137 — thus marked as draft despite being ready, as Reviewable doesn't handle incremental PRs well.]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/138)
<!-- Reviewable:end -->
