### PR TITLE
heap: aggregate fragment alloc/free for single entry

### DIFF
--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -232,7 +232,6 @@ vmemcache_put(VMEMcache *cache, const void *key, size_t ksize,
 	}
 
 	struct cache_entry *entry;
-	struct heap_entry he;
 
 	entry = Zalloc(sizeof(struct cache_entry) + ksize);
 	if (entry == NULL) {
@@ -250,27 +249,20 @@ vmemcache_put(VMEMcache *cache, const void *key, size_t ksize,
 
 	size_t left_to_allocate = value_size;
 
-	while (left_to_allocate > 0) {
-		he = vmcache_alloc(cache->heap, left_to_allocate);
-		if (HEAP_ENTRY_IS_NULL(he)) {
-			if (vmemcache_evict(cache, NULL, 0)) {
-				LOG(1, "vmemcache_evict() failed");
-				if (errno == ESRCH)
-					errno = ENOSPC;
-				goto error_exit;
-			}
-			continue;
+	while (left_to_allocate != 0) {
+		ssize_t allocated = vmcache_alloc(cache->heap, left_to_allocate,
+			&entry->value.fragments);
+		if (allocated < 0) {
+			goto error_exit;
 		}
-
-		if (VEC_PUSH_BACK(&entry->value.fragments, he)) {
-			LOG(1, "out of memory");
+		if (allocated == 0 && vmemcache_evict(cache, NULL, 0)) {
+			LOG(1, "vmemcache_evict() failed");
+			if (errno == ESRCH)
+				errno = ENOSPC;
 			goto error_exit;
 		}
 
-		if (left_to_allocate <= he.size)
-			break;
-
-		left_to_allocate -= he.size;
+		left_to_allocate -= MIN((size_t)allocated, left_to_allocate);
 	}
 
 	if (cache->no_memcpy)
@@ -294,9 +286,7 @@ put_index:
 	return 0;
 
 error_exit:
-	VEC_FOREACH(he, &entry->value.fragments) {
-		vmcache_free(cache->heap, he);
-	}
+	vmcache_free(cache->heap, &entry->value.fragments);
 
 	VEC_DELETE(&entry->value.fragments);
 	Free(entry);
@@ -383,10 +373,7 @@ vmemcache_entry_release(VMEMcache *cache, struct cache_entry *entry)
 	VALGRIND_ANNOTATE_HAPPENS_AFTER(&entry->value.refcount);
 	VALGRIND_ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(&entry->value.refcount);
 
-	struct heap_entry he;
-	VEC_FOREACH(he, &entry->value.fragments) {
-		vmcache_free(cache->heap, he);
-	}
+	vmcache_free(cache->heap, &entry->value.fragments);
 
 	VEC_DELETE(&entry->value.fragments);
 

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -41,7 +41,7 @@
 #include <stddef.h>
 
 #include "libvmemcache.h"
-#include "vec.h"
+#include "vmemcache_heap.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,9 +50,6 @@ extern "C" {
 #define VMEMCACHE_PREFIX "libvmemcache"
 #define VMEMCACHE_LEVEL_VAR "VMEMCACHE_LEVEL"
 #define VMEMCACHE_FILE_VAR "VMEMCACHE_FILE"
-
-/* type of the statistics */
-typedef unsigned long long stat_t;
 
 struct index;
 struct repl_p;
@@ -85,7 +82,7 @@ struct cache_entry {
 		int evicting;
 		struct repl_p_entry *p_entry;
 		size_t vsize;
-		VEC(, struct heap_entry) fragments;
+		struct fragment_vec fragments;
 	} value;
 
 	struct key {

--- a/src/vmemcache_heap.c
+++ b/src/vmemcache_heap.c
@@ -34,7 +34,6 @@
  * vmemcache_heap.c -- implementation of simple vmemcache linear allocator
  */
 
-#include "vmemcache.h"
 #include "vmemcache_heap.h"
 #include "vec.h"
 #include "sys_util.h"
@@ -88,51 +87,75 @@ vmcache_heap_destroy(struct heap *heap)
 
 /*
  * vmcache_alloc -- allocate memory (take it from the queue)
+ *
+ * This function returns the number of allocated bytes if successful,
+ * otherwise -1 is returned.
  */
-struct heap_entry
-vmcache_alloc(struct heap *heap, size_t size)
+ssize_t
+vmcache_alloc(struct heap *heap, size_t size, struct fragment_vec *vec)
 {
 	LOG(3, "heap %p size %zu", heap, size);
 
 	struct heap_entry he = {NULL, 0};
 
 	size = ALIGN_UP(size, heap->fragment_size);
+	size_t to_allocate = size;
 
 	util_mutex_lock(&heap->lock);
 
-	if (VEC_POP_BACK(&heap->entries, &he) != 0)
-		goto error_no_mem;
+	do {
+		if (VEC_POP_BACK(&heap->entries, &he) != 0)
+			break;
 
-	if (he.size > size) {
-		struct heap_entry f;
-		f.ptr = (void *)((uintptr_t)he.ptr + size);
-		f.size = he.size - size;
-		VEC_PUSH_BACK(&heap->entries, f);
+		if (he.size > to_allocate) {
+			struct heap_entry f;
+			f.ptr = (void *)((uintptr_t)he.ptr + to_allocate);
+			f.size = he.size - to_allocate;
+			VEC_PUSH_BACK(&heap->entries, f);
 
-		he.size = size;
-	}
+			he.size = to_allocate;
+		}
 
-	__sync_fetch_and_add(&heap->size_used, he.size);
+		if (VEC_PUSH_BACK(vec, he) != 0) {
+			ERR("!cannot grow fragment vector");
+			goto err_push_back;
+		}
 
-error_no_mem:
+		to_allocate -= he.size;
+	} while (to_allocate != 0);
+
+	__sync_fetch_and_add(&heap->size_used, size - to_allocate);
+
 	util_mutex_unlock(&heap->lock);
 
-	return he;
+	return (ssize_t)(size - to_allocate);
+
+err_push_back:
+	util_mutex_unlock(&heap->lock);
+
+	return -1;
 }
 
 /*
  * vmcache_free -- free memory (give it back to the queue)
  */
 void
-vmcache_free(struct heap *heap, struct heap_entry he)
+vmcache_free(struct heap *heap, struct fragment_vec *vec)
 {
-	LOG(3, "heap %p he.ptr %p he.size %zu", heap, he.ptr, he.size);
+	LOG(3, "heap %p vec %p", heap, vec);
 
 	util_mutex_lock(&heap->lock);
 
-	__sync_fetch_and_sub(&heap->size_used, he.size);
+	size_t freed = 0;
 
-	VEC_PUSH_BACK(&heap->entries, he);
+	struct heap_entry he = {NULL, 0};
+	VEC_FOREACH(he, vec) {
+		VEC_PUSH_BACK(&heap->entries, he);
+		freed += he.size;
+	}
+	VEC_CLEAR(vec);
+
+	__sync_fetch_and_sub(&heap->size_used, freed);
 
 	util_mutex_unlock(&heap->lock);
 }

--- a/src/vmemcache_heap.h
+++ b/src/vmemcache_heap.h
@@ -38,6 +38,10 @@
 #define VMEMCACHE_HEAP_H 1
 
 #include <stddef.h>
+#include "vec.h"
+
+/* type of the statistics */
+typedef unsigned long long stat_t;
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,13 +54,15 @@ struct heap_entry {
 	size_t size;
 };
 
+VEC(fragment_vec, struct heap_entry);
+
 struct heap;
 
 struct heap *vmcache_heap_create(void *addr, size_t size, size_t fragment_size);
 void vmcache_heap_destroy(struct heap *heap);
 
-struct heap_entry vmcache_alloc(struct heap *heap, size_t size);
-void vmcache_free(struct heap *heap, struct heap_entry he);
+ssize_t vmcache_alloc(struct heap *heap, size_t size, struct fragment_vec *vec);
+void vmcache_free(struct heap *heap, struct fragment_vec *vec);
 
 stat_t vmcache_get_heap_used_size(struct heap *heap);
 


### PR DESCRIPTION
This patch speeds-up bench_simul with default parameters by ~4x by aggregating fragment allocations/deallocations under a single lock acquire/release pair.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/140)
<!-- Reviewable:end -->
