### PR TITLE
Let warm_up show up on perf.

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -411,6 +411,9 @@ static void __attribute__((noinline))
 run_warm_up(rng_t *rng, void *get_buffer)
 {
 	run_ops(warm_up, rng, NULL, get_buffer);
+
+	/* Prevent tail call optimizations (to force stack frame, for perf). */
+	getpid();
 }
 
 static void *worker(void *arg)


### PR DESCRIPTION
We want to tell apart warm_up from the rest, without deoptimizing everything else.

It'd be best to disable perf while in warm_up completely, but unless you know how, this kind of works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/142)
<!-- Reviewable:end -->
