### PR TITLE
Use MetroHash for sharding.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
 	util_posix.c
 	file.c
 	file_posix.c
+	metrohash.c
 	mmap.c
 	mmap_posix.c
 	libvmemcache.c

--- a/src/metrohash.c
+++ b/src/metrohash.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015-2018 J. Andrew Rogers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include "metrohash.h"
+
+/* rotate right idiom recognized by most compilers */
+inline static uint64_t
+rotate_right(uint64_t v, unsigned k)
+{
+	return (v >> k) | (v << (64 - k));
+}
+
+static uint64_t read_u64(const void *mem)
+{
+	typedef struct __attribute__((__packed__)) { uint64_t v; } u64_unal;
+	return ((u64_unal *)mem)->v;
+}
+
+static uint32_t read_u32(const void *mem)
+{
+	typedef struct __attribute__((__packed__)) { uint32_t v; } u32_unal;
+	return ((u32_unal *)mem)->v;
+}
+
+static uint16_t read_u16(const void *mem)
+{
+	typedef struct __attribute__((__packed__)) { uint16_t v; } u16_unal;
+	return ((u16_unal *)mem)->v;
+}
+
+static uint8_t read_u8(const void *mem)
+{
+	typedef struct __attribute__((__packed__)) { uint8_t v; } u8_unal;
+	return ((u8_unal *)mem)->v;
+}
+
+uint64_t
+metrohash64(const char *key, uint64_t len /* , uint64_t seed */)
+{
+	static const uint64_t k0 = 0xC83A91E1;
+	static const uint64_t k1 = 0x8648DBDB;
+	static const uint64_t k2 = 0x7BDEC03B;
+	static const uint64_t k3 = 0x2F5870A5;
+
+	const uint8_t * ptr = (const uint8_t *)key;
+	const uint8_t * const end = ptr + len;
+
+	uint64_t hash = ((/* seed + */ k2) * k0) + len;
+
+	if (len >= 32) {
+		uint64_t v[4];
+		v[0] = hash;
+		v[1] = hash;
+		v[2] = hash;
+		v[3] = hash;
+
+		do {
+			v[0] += read_u64(ptr) * k0;
+			ptr += 8;
+			v[0] = rotate_right(v[0], 29) + v[2];
+			v[1] += read_u64(ptr) * k1;
+			ptr += 8;
+			v[1] = rotate_right(v[1], 29) + v[3];
+			v[2] += read_u64(ptr) * k2;
+			ptr += 8;
+			v[2] = rotate_right(v[2], 29) + v[0];
+			v[3] += read_u64(ptr) * k3;
+			ptr += 8;
+			v[3] = rotate_right(v[3], 29) + v[1];
+		} while (ptr <= (end - 32));
+
+		v[2] ^= rotate_right(((v[0] + v[3]) * k0) + v[1], 33) * k1;
+		v[3] ^= rotate_right(((v[1] + v[2]) * k1) + v[0], 33) * k0;
+		v[0] ^= rotate_right(((v[0] + v[2]) * k0) + v[3], 33) * k1;
+		v[1] ^= rotate_right(((v[1] + v[3]) * k1) + v[2], 33) * k0;
+		hash += v[0] ^ v[1];
+	}
+
+	if ((end - ptr) >= 16) {
+		uint64_t v0 = hash + (read_u64(ptr) * k0);
+		ptr += 8;
+		v0 = rotate_right(v0, 33) * k1;
+		uint64_t v1 = hash + (read_u64(ptr) * k1);
+		ptr += 8;
+		v1 = rotate_right(v1, 33) * k2;
+		v0 ^= rotate_right(v0 * k0, 35) + v1;
+		v1 ^= rotate_right(v1 * k3, 35) + v0;
+		hash += v1;
+	}
+
+	if ((end - ptr) >= 8) {
+		hash += read_u64(ptr) * k3; ptr += 8;
+		hash ^= rotate_right(hash, 33) * k1;
+
+	}
+
+	if ((end - ptr) >= 4) {
+		hash += read_u32(ptr) * k3; ptr += 4;
+		hash ^= rotate_right(hash, 15) * k1;
+	}
+
+	if ((end - ptr) >= 2) {
+		hash += read_u16(ptr) * k3; ptr += 2;
+		hash ^= rotate_right(hash, 13) * k1;
+	}
+
+	if ((end - ptr) >= 1) {
+		hash += read_u8(ptr) * k3;
+		hash ^= rotate_right(hash, 25) * k1;
+	}
+
+	hash ^= rotate_right(hash, 33);
+	hash *= k0;
+	hash ^= rotate_right(hash, 33);
+
+	return hash;
+}

--- a/src/metrohash.h
+++ b/src/metrohash.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2018 J. Andrew Rogers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+uint64_t metrohash64(const char *key, uint64_t len);

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -42,6 +42,7 @@
 #include "vmemcache_index.h"
 #include "critnib.h"
 #include "sys_util.h"
+#include "metrohash.h"
 
 /* must be a power of 2 */
 #define NSHARDS 256
@@ -57,10 +58,7 @@ struct index {
 static int
 shard_id(size_t key_size, const char *key)
 {
-	/* Fowler–Noll–Vo hash */
-	uint64_t h = 0xcbf29ce484222325;
-	for (size_t i = 0; i < key_size; i++)
-		h = (h ^ (unsigned char)*key++) * 0x100000001b3;
+	uint64_t h = metrohash64(key, key_size);
 
 	return h & (NSHARDS - 1);
 }

--- a/utils/check_license/file-exceptions.sh
+++ b/utils/check_license/file-exceptions.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,4 +33,4 @@
 
 # file-exceptions.sh - filter out files not checked for copyright and license
 
-grep -v -E -e '/queue.h$'
+grep -v -E -e '/queue.h$|/metrohash'


### PR DESCRIPTION
Calculating the hash isn't an especially prominent part on perf output, but it's not beneath notice — and, improving it is a matter of plugging in a ready hash.  Thus, low gain, low effort — for a low-hanging fruit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/143)
<!-- Reviewable:end -->
