### PR TITLE
Unbreak ｢ctest -j｣.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,7 +82,7 @@ function(test name file tracer location)
 		${GLOBAL_TEST_ARGS}
 		-DTEST_NAME=${name}
 		-DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-		-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${file}
+		-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${file}-${tracer}-${location}
 		-DCONFIG=$<CONFIG>
 		-DTRACER=${tracer}
 		-DTEST_POOL_LOCATION=${TEST_POOL_LOCATION}


### PR DESCRIPTION
Using the same "private" directory for different versions of the same test, and tearing them up after each run, doesn't work concurrently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/145)
<!-- Reviewable:end -->
