### PR TITLE
simul: warm_up improvements

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -625,6 +625,9 @@ static void run_bench()
 		type <= ST_INDEX);
 	/* memcpy is enabled after warm_up */
 	vmemcache_bench_set(cache, VMEMCACHE_BENCH_NO_MEMCPY, 1);
+	/* but if there's any warm_up, touch the space once */
+	if (warm_up)
+		vmemcache_bench_set(cache, VMEMCACHE_BENCH_PREFAULT, 1);
 
 	os_thread_t th[MAX_THREADS];
 	for (uint64_t i = 0; i < n_threads; i++) {

--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -442,8 +442,13 @@ static void *worker(void *arg)
 	os_mutex_lock(&ready.mutex);
 	if (--ready.wanted)
 		os_cond_wait(&ready.cond, &ready.mutex);
-	else
+	else {
+		/* If warm_up disabled memcpy, re-enable it. */
+		vmemcache_bench_set(cache, VMEMCACHE_BENCH_NO_MEMCPY,
+			type < ST_FULL);
+
 		os_cond_broadcast(&ready.cond);
+	}
 	os_mutex_unlock(&ready.mutex);
 
 	benchmark_time_t t1, t2;
@@ -618,8 +623,8 @@ static void run_bench()
 
 	vmemcache_bench_set(cache, VMEMCACHE_BENCH_INDEX_ONLY,
 		type <= ST_INDEX);
-	vmemcache_bench_set(cache, VMEMCACHE_BENCH_NO_MEMCPY,
-		type < ST_FULL);
+	/* memcpy is enabled after warm_up */
+	vmemcache_bench_set(cache, VMEMCACHE_BENCH_NO_MEMCPY, 1);
 
 	os_thread_t th[MAX_THREADS];
 	for (uint64_t i = 0; i < n_threads; i++) {

--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -168,6 +168,12 @@ static const char *stat_str[VMEMCACHE_STATS_NUM] = {
 	"pool size used"
 };
 
+static struct {
+	os_cond_t cond;
+	os_mutex_t mutex;
+	uint64_t wanted;
+} ready;
+
 static void print_stats(VMEMcache *cache);
 
 /*
@@ -433,6 +439,13 @@ static void *worker(void *arg)
 
 	run_warm_up(&rng, get_buffer);
 
+	os_mutex_lock(&ready.mutex);
+	if (--ready.wanted)
+		os_cond_wait(&ready.cond, &ready.mutex);
+	else
+		os_cond_broadcast(&ready.cond);
+	os_mutex_unlock(&ready.mutex);
+
 	benchmark_time_t t1, t2;
 	benchmark_time_get(&t1);
 
@@ -569,6 +582,10 @@ static void run_bench()
 	rng_t rng;
 	randomize_r(&rng, seed);
 	vsize_seed = rnd64_r(&rng);
+
+	os_cond_init(&ready.cond);
+	os_mutex_init(&ready.mutex);
+	ready.wanted = n_threads;
 
 	cache = vmemcache_new(dir, cache_size, cache_extent_size,
 		(enum vmemcache_replacement_policy)repl_policy);

--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -105,6 +105,7 @@ enum vmemcache_bench_cfg {
 	VMEMCACHE_BENCH_INDEX_ONLY,	/* disable anything but indexing */
 	VMEMCACHE_BENCH_NO_ALLOC,	/* index+repl but no alloc */
 	VMEMCACHE_BENCH_NO_MEMCPY,	/* alloc but don't copy data */
+	VMEMCACHE_BENCH_PREFAULT,	/* prefault the whole pool */
 };
 
 typedef void vmemcache_on_evict(VMEMcache *cache,

--- a/src/os_thread_posix.c
+++ b/src/os_thread_posix.c
@@ -288,7 +288,6 @@ os_spin_trylock(os_spinlock_t *lock)
 }
 #endif
 
-#if 0
 /*
  * os_cond_init -- pthread_cond_init abstraction layer
  */
@@ -347,7 +346,6 @@ os_cond_wait(os_cond_t *__restrict cond,
 	return pthread_cond_wait((pthread_cond_t *)cond,
 		(pthread_mutex_t *)mutex);
 }
-#endif
 
 /*
  * os_thread_create -- pthread_create abstraction layer


### PR DESCRIPTION
After even modest warm up, the allocator rapidly degenerates.  Thus, let's make it easier to run long warm ups quickly.

So let's skip memcpy during it — instead, clobber the cache just enough to prefault it.

Also, long warm_up may get a thread faster than others, resulting in stragglers to have a nice uncontended cache, falsifying the results.  Thus, let's synchronize all threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/146)
<!-- Reviewable:end -->
