### PR TITLE
Fix an (invalid) compiler warning.

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -373,7 +373,7 @@ static inline uint64_t getticks(void)
 static void
 run_ops(uint64_t ops, rng_t *rng, uint64_t *lat, void *get_buffer)
 {
-	uint64_t opt;
+	uint64_t opt, opt_tag;
 
 	for (uint64_t count = 0; count < ops; count++) {
 		uint64_t obj = n_lowest_bits(rnd64_r(rng), (int)key_diversity);
@@ -399,11 +399,13 @@ run_ops(uint64_t ops, rng_t *rng, uint64_t *lat, void *get_buffer)
 						vmemcache_errormsg());
 			}
 
-			if (lat)
-				*lat++ = (getticks() - opt) | PUT_TAG;
-		} else if (lat) {
-			*lat++ = getticks() - opt;
+			opt_tag = PUT_TAG;
+		} else {
+			opt_tag = 0;
 		}
+
+		if (lat)
+			*lat++ = (getticks() - opt) | opt_tag;
 	}
 }
 


### PR DESCRIPTION
The warning is a false positive due to gcc's flow analyzer behaving weirdly.

Interestingly, it's not because it doesn't **see** the variable having no way of being changed from the outside — as moving the check **later** avoids the warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/152)
<!-- Reviewable:end -->
