### PR TITLE
test: fix example test

### DIFF
--- a/tests/example.c
+++ b/tests/example.c
@@ -54,13 +54,19 @@ get(const char *key)
 	if (len >= 0)
 		printf("%.*s\n", (int)len, buf);
 	else
-		printf("(not found)\n");
+		printf("(key not found: %s)\n", key);
 }
 
 int
 main()
 {
-	cache = vmemcache_new("/tmp", 1048576, 256, VMEMCACHE_REPLACEMENT_LRU);
+	cache = vmemcache_new("/tmp", VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
+				VMEMCACHE_REPLACEMENT_LRU);
+	if (cache == NULL) {
+		fprintf(stderr, "error: vmemcache_new: %s\n",
+				vmemcache_errormsg());
+		return -1;
+	}
 
 	/* Query a non-existent key. */
 	get("meow");


### PR DESCRIPTION
If 'minimum pool size' or 'minimum size of extent' changes,
vmemcache_new() can fail and the test would segfault,
so:
1) the predefined constants:
- VMEMCACHE_MIN_POOL and VMEMCACHE_MIN_EXTENT
have to be used instead of hardcoded values and
2) failure of vmemcache_new() has to be handled properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/156)
<!-- Reviewable:end -->
