### PR TITLE
simul: print what stage the benchmark is doing

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -447,6 +447,8 @@ static void *worker(void *arg)
 		vmemcache_bench_set(cache, VMEMCACHE_BENCH_NO_MEMCPY,
 			type < ST_FULL);
 
+		printf("Starting measured run...\n");
+
 		os_cond_broadcast(&ready.cond);
 	}
 	os_mutex_unlock(&ready.mutex);
@@ -608,6 +610,8 @@ static void run_bench()
 	}
 
 	if (junk_start) {
+		printf("Pre-filling the cache with junk...\n");
+
 		char junk[256];
 		memset(junk, '!' /* arbitrary */, sizeof(junk));
 
@@ -629,6 +633,8 @@ static void run_bench()
 	if (warm_up)
 		vmemcache_bench_set(cache, VMEMCACHE_BENCH_PREFAULT, 1);
 
+	printf("Spawning threads...\n");
+
 	os_thread_t th[MAX_THREADS];
 	for (uint64_t i = 0; i < n_threads; i++) {
 		if (os_thread_create(&th[i], 0, worker, (void *)i))
@@ -643,6 +649,8 @@ static void run_bench()
 			UT_FATAL("thread join failed: %s", strerror(errno));
 		total += t;
 	}
+
+	printf("Done.\n");
 
 	print_stats(cache);
 


### PR DESCRIPTION
It may be interesting whether we're doing junk_start, warm_up or the real run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/158)
<!-- Reviewable:end -->
