### PR TITLE
vec: reduce initial size of vec to 1

### DIFF
--- a/src/vec.h
+++ b/src/vec.h
@@ -46,7 +46,7 @@
 extern "C" {
 #endif
 
-#define VEC_INIT_SIZE (64)
+#define VEC_INIT_SIZE (1)
 
 #define VEC(name, type)\
 struct name {\


### PR DESCRIPTION
This significantly reduces DRAM footprint of vmemcache because
right now all VEC(struct heap_extent) structures are initialized
with 1 kilobyte of entries which are most likely never used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/159)
<!-- Reviewable:end -->
