### PR TITLE
man: produce proper definition lists

### DIFF
--- a/doc/vmemcache.md
+++ b/doc/vmemcache.md
@@ -81,73 +81,60 @@ in memory (tmpfs) or, less performant, on some kind of a disk.
 
 ##### Creation #####
 
-```
-VMEMcache *vmemcache_new(const char *path, size_t max_size, size_t extent_size,
-	enum vmemcache_replacement_policy replacement_policy);
-```
+`VMEMcache *vmemcache_new(const char *path, size_t max_size, size_t extent_size, enum vmemcache_replacement_policy replacement_policy);`
 
-The cache will be created in the given *path*, which may be:
- + a `/dev/dax` device
- + a directory on a regular filesystem (which may or may not be mounted with
-   -o dax, either on persistent memory or any other backing)
+:   The cache will be created in the given *path*, which may be:
 
-Its size is given as *max_size*, although it is rounded **up** towards a
-whole page size alignment (4KB on x86, 64KB on ppc, 4/16/64KB on arm64).
+    + a `/dev/dax` device
+    + a directory on a regular filesystem (which may or may not be mounted with
+      -o dax, either on persistent memory or any other backing)
 
-*extent_size* affects allowed fragmentation of the cache. Reducing it
-improves cache space utilization, increasing it improves performance.
+    Its size is given as *max_size*, although it is rounded **up** towards a
+    whole page size alignment (4KB on x86, 64KB on ppc, 4/16/64KB on arm64).
 
-*replacement_policy* may be:
- + **VMEMCACHE_REPLACEMENT_NONE**: manual eviction only - puts into a full
-   cache will fail
- + **VMEMCACHE_REPLACEMENT_LRU**: least recently accessed entry will be evicted
-   to make space when needed
+    *extent_size* affects allowed fragmentation of the cache. Reducing it
+    improves cache space utilization, increasing it improves performance.
+
+    *replacement_policy* may be:
+
+    + **VMEMCACHE_REPLACEMENT_NONE**: manual eviction only - puts into a full
+      cache will fail
+    + **VMEMCACHE_REPLACEMENT_LRU**: least recently accessed entry will be evicted
+      to make space when needed
 
 
-```
-void vmemcache_delete(VMEMcache *cache);
-```
+`void vmemcache_delete(VMEMcache *cache);`
 
-Frees any structures associated with the cache.
+:   Frees any structures associated with the cache.
 
 
 ##### Use #####
 
-```
-ssize_t vmemcache_get(VMEMcache *cache,
-	const void *key, size_t key_size,
-	void *vbuf, size_t vbufsize, size_t offset, size_t *vsize);
-```
+`ssize_t vmemcache_get(VMEMcache *cache, const void *key, size_t key_size, void *vbuf, size_t vbufsize, size_t offset, size_t *vsize);`
 
-Searches for an entry with the given *key*; it doesn't have to be
-zero-terminated or be text - any sequence of bytes of length *key_size*
-is okay. If found, the entry's value is copied to *vbuf* that has space
-for *vbufsize* bytes, optionally skipping *offset* bytes at the start.
-No matter if the copy was truncated or not, its true size is stored into
-*vsize*; *vsize* remains unmodified if the key was not found.
+:   Searches for an entry with the given *key*; it doesn't have to be
+    zero-terminated or be text - any sequence of bytes of length *key_size*
+    is okay. If found, the entry's value is copied to *vbuf* that has space
+    for *vbufsize* bytes, optionally skipping *offset* bytes at the start.
+    No matter if the copy was truncated or not, its true size is stored into
+    *vsize*; *vsize* remains unmodified if the key was not found.
 
-Return value is number of bytes successfully copied, or -1 on error.
-In particular, if there's no entry for the given *key* in the cache,
-the errno will be ENOENT.
+    Return value is number of bytes successfully copied, or -1 on error.
+    In particular, if there's no entry for the given *key* in the cache,
+    the errno will be ENOENT.
 
 
-```
-int vmemcache_put(VMEMcache *cache,
-	const void *key, size_t key_size,
-	const void *value, size_t value_size);
-```
+`int vmemcache_put(VMEMcache *cache, const void *key, size_t key_size, const void *value, size_t value_size);`
 
-Inserts the given key:value pair into the cache. Returns 0 on success,
--1 on error. Inserting a key that already exists will fail with EEXIST.
+:   Inserts the given key:value pair into the cache. Returns 0 on success,
+    -1 on error. Inserting a key that already exists will fail with EEXIST.
 
 
-```
-int vmemcache_evict(VMEMcache *cache, const void *key, size_t ksize);
-```
+`int vmemcache_evict(VMEMcache *cache, const void *key, size_t ksize);`
 
-Removes the given key from the cache. If *key* is null and there is a
-replacement policy set, the oldest entry will be removed. Returns 0 if
-an entry has been evicted, -1 otherwise.
+:   Removes the given key from the cache. If *key* is null and there is a
+    replacement policy set, the oldest entry will be removed. Returns 0 if
+    an entry has been evicted, -1 otherwise.
 
 
 ##### Callbacks #####
@@ -156,78 +143,61 @@ You can register a hook to be called during eviction or after a cache miss,
 using **vmemcache_callback_on_evict()** or **vmemcache_callback_on_miss()**,
 respectively. The extra *arg* will be passed to your function.
 
-```
-void vmemcache_on_evict(VMEMcache *cache,
-	const void *key, size_t key_size, void *arg);
-```
+`void vmemcache_on_evict(VMEMcache *cache, const void *key, size_t key_size, void *arg);`
 
-Called when an entry is being removed from the cache. The eviction can't
-be prevented, but until the callback returns, the entry remains available
-for queries. The thread that triggered the eviction is blocked in the
-meantime.
+:   Called when an entry is being removed from the cache. The eviction can't
+    be prevented, but until the callback returns, the entry remains available
+    for queries. The thread that triggered the eviction is blocked in the
+    meantime.
 
 
-```
-void vmemcache_on_miss(VMEMcache *cache,
-	const void *key, size_t key_size, void *arg);
-```
+`void vmemcache_on_miss(VMEMcache *cache, const void *key, size_t key_size, void *arg);`
 
-Called when a *get* query fails, to provide an opportunity to insert the
-missing key. If the callback calls *put* for that specific key, the *get*
-will return its value, even if it did not fit into the cache.
+:   Called when a *get* query fails, to provide an opportunity to insert the
+    missing key. If the callback calls *put* for that specific key, the *get*
+    will return its value, even if it did not fit into the cache.
 
 
 ##### Misc #####
 
-```
-int vmemcache_get_stat(VMEMcache *cache,
-	enum vmemcache_statistic stat,
-	void *value, size_t value_size);
-```
+`int vmemcache_get_stat(VMEMcache *cache, enum vmemcache_statistic stat, void *value, size_t value_size);`
 
-Obtains a piece of statistics about the cache. The *stat* may be:
- + **VMEMCACHE_STAT_PUT**
-	count of puts
- + **VMEMCACHE_STAT_GET**
-	count of gets
- + **VMEMCACHE_STAT_HIT**
-	count of gets that were served from the cache
- + **VMEMCACHE_STAT_MISS**
-	count of gets that were not present in the cache
- + **VMEMCACHE_STAT_EVICT**
-	count of evictions
- + **VMEMCACHE_STAT_ENTRIES**
-	*current* number of cache entries
- + **VMEMCACHE_STAT_DRAM_SIZE_USED**
-	current amount of DRAM used for keys
+:   Obtains a piece of statistics about the cache. The *stat* may be:
+
+    + **VMEMCACHE_STAT_PUT**
+	-- count of puts
+    + **VMEMCACHE_STAT_GET**
+	-- count of gets
+    + **VMEMCACHE_STAT_HIT**
+	-- count of gets that were served from the cache
+    + **VMEMCACHE_STAT_MISS**
+	-- count of gets that were not present in the cache
+    + **VMEMCACHE_STAT_EVICT**
+	-- count of evictions
+    + **VMEMCACHE_STAT_ENTRIES**
+	-- *current* number of cache entries
+    + **VMEMCACHE_STAT_DRAM_SIZE_USED**
+	-- current amount of DRAM used for keys
 	CLARIFY/RENAME: doesn't include index, repl nor allocator
- + **VMEMCACHE_STAT_POOL_SIZE_USED**
-	current usage of data pool
- + **VMEMCACHE_STAT_HEAP_ENTRIES**
-	current number of heap entries
+    + **VMEMCACHE_STAT_POOL_SIZE_USED**
+	-- current usage of data pool
+    + **VMEMCACHE_STAT_HEAP_ENTRIES**
+	-- current number of heap entries
 
 
-```
-const char *vmemcache_errormsg(void);
-```
+`const char *vmemcache_errormsg(void);`
 
-Retrieves a human-friendly description of the last error.
+:   Retrieves a human-friendly description of the last error.
 
 
 ##### Errors #####
 
 On an error, a machine-usable description is passed in `errno`. It may be:
- + **EINVAL**
-	nonsensical/invalid parameter
- + **ENOMEM**
-	out of DRAM
- + **EEXIST**
-	(put) entry for that key already exists
- + **ENOENT**
-	(evict, get) no entry for that key
- + **ESRCH**
-	(evict) could not find an evictable entry
- + **EAGAIN**
-	(evict) an entry was used and could not be evicted, please try again
- + **ENOSPC**
-	(create, put) not enough space in the memory pool
+
++ **EINVAL** -- nonsensical/invalid parameter
++ **ENOMEM** -- out of DRAM
++ **EEXIST** -- (put) entry for that key already exists
++ **ENOENT** -- (evict, get) no entry for that key
++ **ESRCH** -- (evict) could not find an evictable entry
++ **EAGAIN** -- (evict) an entry was used and could not be evicted, please try again
++ **ENOSPC** -- (create, put) not enough space in the memory pool


### PR DESCRIPTION
pandoc requires a pretty quirky syntax; naïve markdown results in reversed indentation — option header was to the right, body text to the left.  This reformatting produces a more man-like page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/168)
<!-- Reviewable:end -->
