### PR TITLE
int size fixes

### DIFF
--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -646,7 +646,7 @@ static void run_bench()
 	uint64_t total = 0;
 
 	for (uint64_t i = 0; i < n_threads; i++) {
-		uint64_t t;
+		uintptr_t t;
 		if (os_thread_join(&th[i], (void **)&t))
 			UT_FATAL("thread join failed: %s", strerror(errno));
 		total += t;

--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -44,6 +44,7 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/mman.h>
+#include <inttypes.h>
 
 #include "libvmemcache.h"
 #include "test_helpers.h"
@@ -687,7 +688,7 @@ print_units(uint64_t x)
 		x /= 1024;
 	}
 
-	printf("%lu%s", x, units[u]);
+	printf("%"PRIu64"%s", x, units[u]);
 }
 
 int

--- a/src/critnib.c
+++ b/src/critnib.c
@@ -74,7 +74,7 @@ typedef struct cache_entry critnib_leaf;
 static inline bool
 is_leaf(struct critnib_node *n)
 {
-	return (uint64_t)n & 1;
+	return (uintptr_t)n & 1;
 }
 
 /*
@@ -83,7 +83,7 @@ is_leaf(struct critnib_node *n)
 static inline critnib_leaf *
 to_leaf(struct critnib_node *n)
 {
-	return (void *)((uint64_t)n & ~1ULL);
+	return (void *)((uintptr_t)n & ~1ULL);
 }
 
 /*
@@ -175,7 +175,7 @@ critnib_set(struct critnib *c, struct cache_entry *e)
 {
 	const char *key = (void *)&e->key;
 	byten_t key_len = (byten_t)KEYLEN(e);
-	critnib_leaf *k = (void *)((uint64_t)e | 1);
+	critnib_leaf *k = (void *)((uintptr_t)e | 1);
 
 	struct critnib_node *n = c->root;
 	if (!n) {

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -118,7 +118,7 @@ vmemcache_newU(const char *dir, size_t max_size, size_t extent_size,
 
 		if (max_size != 0 && max_size > (size_t)size) {
 			ERR(
-				"error: maximum cache size (%zu) is bigger than the size of the DAX device (%li)",
+				"error: maximum cache size (%zu) is bigger than the size of the DAX device (%zi)",
 				max_size, size);
 			errno = EINVAL;
 			goto error_free_cache;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -59,13 +59,14 @@
 } while (/*CONSTCOND*/0)
 
 #define UT_ASSERTeq(x, y) do if ((x) != (y)) {\
-	UT_FATAL("ASSERT FAILED : " #x " (%zu) ≠ %zu",\
-		(uint64_t)(x), (uint64_t)(y));\
+	UT_FATAL("ASSERT FAILED : " #x " (%llu) ≠ %llu",\
+		(unsigned long long)(x), (unsigned long long)(y));\
 } while (/*CONSTCOND*/0)
 
 #define UT_ASSERTin(x, min, max) do if ((x) < (min) || (x) > (max)) {\
-	UT_FATAL("ASSERT FAILED : " #x " = %zu not in [%zu,%zu]", (x),\
-		(uint64_t)(min), (uint64_t)(max));\
+	UT_FATAL("ASSERT FAILED : " #x " = %llu not in [%llu,%llu]",\
+		(unsigned long long)(x),\
+		(unsigned long long)(min), (unsigned long long)(max));\
 } while (/*CONSTCOND*/0)
 
 

--- a/tests/vmemcache_test_utilization.c
+++ b/tests/vmemcache_test_utilization.c
@@ -224,7 +224,7 @@ put_until_timeout(VMEMcache *vc, const test_params *p)
 	}
 
 	size_t val_size;
-	size_t used_size;
+	unsigned long long used_size;
 	char key[MAX_KEYSIZE];
 	int len;
 	size_t keynum = 0;


### PR DESCRIPTION
It's better to use appropriate types, such as *intptr_t* for pointer, even when their width is known — more readable, and will make eventual porting to platforms with a weird type scheme such as Windows easier.

There's also a 32-bit crash fix due to printf mismatch.  I did not bother to fix warnings, merely made vmemcache build and pass all tests — we don't care about 32-bit, but if I can make it all green at such a small cost, why not?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/172)
<!-- Reviewable:end -->
