### PR TITLE
Make cmake complain if pandoc is not present.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ else()
 endif()
 
 find_program(PANDOC NAMES pandoc)
+if(NOT PANDOC)
+	message(WARNING "pandoc not found - documentation will not be generated")
+endif()
 
 set(CMAKE_C_STANDARD 99)
 


### PR DESCRIPTION
Just a WARNING rather than FATAL_ERROR.  Do we want the latter?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/180)
<!-- Reviewable:end -->
