### PR TITLE
cut cache_entry refcounts to 32 bits

### DIFF
--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -390,7 +390,7 @@ vmemcache_populate_value(void *vbuf, size_t vbufsize, size_t offset,
 void
 vmemcache_entry_acquire(struct cache_entry *entry)
 {
-	uint64_t ret = util_fetch_and_add64(&entry->value.refcount, 1);
+	uint64_t ret = util_fetch_and_add32(&entry->value.refcount, 1);
 
 	ASSERTne(ret, 0);
 }
@@ -401,7 +401,7 @@ vmemcache_entry_acquire(struct cache_entry *entry)
 void
 vmemcache_entry_release(VMEMcache *cache, struct cache_entry *entry)
 {
-	if (util_fetch_and_sub64(&entry->value.refcount, 1) != 1) {
+	if (util_fetch_and_sub32(&entry->value.refcount, 1) != 1) {
 		VALGRIND_ANNOTATE_HAPPENS_BEFORE(&entry->value.refcount);
 		return;
 	}

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -78,7 +78,7 @@ struct vmemcache {
 
 struct cache_entry {
 	struct value {
-		uint64_t refcount;
+		uint32_t refcount;
 		int evicting;
 		struct repl_p_entry *p_entry;
 		size_t vsize;


### PR DESCRIPTION
A low-hanging fruit for reducing DRAM usage by 8 bytes per entry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/183)
<!-- Reviewable:end -->
