### PR TITLE
new vmemcache_new() API: separate config

### DIFF
--- a/benchmarks/bench_micro.c
+++ b/benchmarks/bench_micro.c
@@ -75,8 +75,11 @@ bench_init(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_replacement_policy replacement_policy,
 		unsigned n_threads, struct context *ctx)
 {
-	VMEMcache *cache = vmemcache_new(path, size, extent_size,
-						replacement_policy);
+	VMEMconfig *cfg = vmemcache_config_new();
+	vmemcache_config_set_size(cfg, size);
+	vmemcache_config_set_eviction_policy(cfg, replacement_policy);
+	VMEMcache *cache = vmemcache_new(path, cfg);
+	vmemcache_config_delete(cfg);
 	if (cache == NULL)
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), path);
 

--- a/benchmarks/bench_micro.c
+++ b/benchmarks/bench_micro.c
@@ -71,11 +71,11 @@ struct context {
  * bench_init -- (internal) initialize benchmark
  */
 static VMEMcache *
-bench_init(const char *path, size_t max_size, size_t extent_size,
+bench_init(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_replacement_policy replacement_policy,
 		unsigned n_threads, struct context *ctx)
 {
-	VMEMcache *cache = vmemcache_new(path, max_size, extent_size,
+	VMEMcache *cache = vmemcache_new(path, size, extent_size,
 						replacement_policy);
 	if (cache == NULL)
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), path);
@@ -196,12 +196,12 @@ print_bench_results(const char *op_name, unsigned n_threads,
  * run_test_put -- (internal) run test for vmemcache_put()
  */
 static void
-run_bench_put(const char *path, size_t max_size, size_t extent_size,
+run_bench_put(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_replacement_policy replacement_policy,
 		unsigned n_threads, os_thread_t *threads,
 		unsigned ops_count, struct context *ctx)
 {
-	VMEMcache *cache = bench_init(path, max_size, extent_size,
+	VMEMcache *cache = bench_init(path, size, extent_size,
 					replacement_policy, n_threads, ctx);
 
 	unsigned ops_per_thread = ops_count / n_threads;
@@ -237,12 +237,12 @@ on_evict_cb(VMEMcache *cache, const void *key, size_t key_size, void *arg)
  * run_bench_get -- (internal) run test for vmemcache_get()
  */
 static void
-run_bench_get(const char *path, size_t max_size, size_t extent_size,
+run_bench_get(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_replacement_policy replacement_policy,
 		unsigned n_threads, os_thread_t *threads,
 		unsigned ops_count, struct context *ctx)
 {
-	VMEMcache *cache = bench_init(path, max_size, extent_size,
+	VMEMcache *cache = bench_init(path, size, extent_size,
 					replacement_policy, n_threads, ctx);
 
 	int cache_is_full = 0;
@@ -279,13 +279,13 @@ run_bench_get(const char *path, size_t max_size, size_t extent_size,
 }
 
 #define USAGE_STRING \
-"usage: %s <directory> [benchmark] [threads] [ops_count] [cache_max_size] [cache_extent_size] [nbuffs] [min_size] [max_size] [seed]\n"\
+"usage: %s <directory> [benchmark] [threads] [ops_count] [cache_size] [cache_extent_size] [nbuffs] [min_size] [max_size] [seed]\n"\
 "       [benchmark] - can be: all (default), put or get\n"\
 "       Default values of parameters:\n"\
 "       - benchmark           = all (put and get)\n"\
 "       - threads             = %u\n"\
 "       - ops_count           = %u\n"\
-"       - cache_max_size      = %u\n"\
+"       - cache_size          = %u\n"\
 "       - cache_extent_size   = %u\n"\
 "       - nbuffs              = %u\n"\
 "       - min_size            = %u\n"\
@@ -302,7 +302,7 @@ main(int argc, char *argv[])
 	unsigned benchmark = BENCH_ALL;
 	unsigned n_threads = 10;
 	unsigned ops_count = 100000;
-	unsigned cache_max_size = VMEMCACHE_MIN_POOL;
+	unsigned cache_size = VMEMCACHE_MIN_POOL;
 	unsigned cache_extent_size = VMEMCACHE_MIN_EXTENT;
 	unsigned nbuffs = 10;
 	unsigned min_size = 128;
@@ -310,7 +310,7 @@ main(int argc, char *argv[])
 
 	if (argc < 2 || argc > 11) {
 		fprintf(stderr, USAGE_STRING, argv[0], n_threads, ops_count,
-			cache_max_size, cache_extent_size,
+			cache_size, cache_extent_size,
 			nbuffs, min_size, max_size);
 		exit(-1);
 	}
@@ -340,9 +340,9 @@ main(int argc, char *argv[])
 		UT_FATAL("incorrect value of ops_count: %s", argv[4]);
 
 	if (argc >= 6 &&
-	    (str_to_unsigned(argv[5], &cache_max_size) ||
-			    cache_max_size < VMEMCACHE_MIN_POOL))
-		UT_FATAL("incorrect value of cache_max_size: %s", argv[5]);
+	    (str_to_unsigned(argv[5], &cache_size) ||
+			    cache_size < VMEMCACHE_MIN_POOL))
+		UT_FATAL("incorrect value of cache_size: %s", argv[5]);
 
 	if (argc >= 7 &&
 	    (str_to_unsigned(argv[6], &cache_extent_size) ||
@@ -373,7 +373,7 @@ main(int argc, char *argv[])
 	printf("   directory           : %s\n", dir);
 	printf("   n_threads           : %u\n", n_threads);
 	printf("   ops_count           : %u\n", ops_count);
-	printf("   cache_max_size      : %u\n", cache_max_size);
+	printf("   cache_size          : %u\n", cache_size);
 	printf("   cache_extent_size   : %u\n", cache_extent_size);
 	printf("   nbuffs              : %u\n", nbuffs);
 	printf("   min_size            : %u\n", min_size);
@@ -414,12 +414,12 @@ main(int argc, char *argv[])
 		UT_FATAL("out of memory");
 
 	if (benchmark & BENCH_PUT)
-		run_bench_put(dir, cache_max_size, cache_extent_size,
+		run_bench_put(dir, cache_size, cache_extent_size,
 				VMEMCACHE_REPLACEMENT_LRU,
 				n_threads, threads, ops_count, ctx);
 
 	if (benchmark & BENCH_GET)
-		run_bench_get(dir, cache_max_size, cache_extent_size,
+		run_bench_get(dir, cache_size, cache_extent_size,
 				VMEMCACHE_REPLACEMENT_LRU,
 				n_threads, threads, ops_count, ctx);
 

--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -603,8 +603,12 @@ static void run_bench()
 	os_mutex_init(&ready.mutex);
 	ready.wanted = n_threads;
 
-	cache = vmemcache_new(dir, cache_size, cache_extent_size,
-		(enum vmemcache_replacement_policy)repl_policy);
+	VMEMconfig *cfg = vmemcache_config_new();
+	vmemcache_config_set_size(cfg, cache_size);
+	vmemcache_config_set_extent_size(cfg, cache_extent_size);
+	vmemcache_config_set_eviction_policy(cfg, (enum vmemcache_replacement_policy)repl_policy);
+	cache = vmemcache_new(dir, cfg);
+	vmemcache_config_delete(cfg);
 	if (!cache)
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), dir);
 

--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -125,15 +125,10 @@ void vmemcache_config_set_size(VMEMconfig *cfg, size_t size);
 void vmemcache_config_set_extent_size(VMEMconfig *cfg, size_t extent_size);
 
 #ifndef _WIN32
-VMEMcache *vmemcache_new(const char *path, size_t max_size, size_t extent_size,
-		enum vmemcache_replacement_policy replacement_policy);
+VMEMcache *vmemcache_new(const char *path, VMEMconfig *cfg);
 #else
-VMEMcache *vmemcache_newU(const char *path, size_t max_size,
-		size_t extent_size,
-		enum vmemcache_replacement_policy replacement_policy);
-VMEMcache *vmemcache_newW(const wchar_t *path, size_t max_size,
-		size_t extent_size,
-		enum vmemcache_replacement_policy replacement_policy);
+VMEMcache *vmemcache_newU(const char *path, VMEMconfig *cfg);
+VMEMcache *vmemcache_newW(const wchar_t *path, VMEMconfig *cfg);
 #endif
 
 void vmemcache_delete(VMEMcache *cache);

--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -79,6 +79,7 @@ extern "C" {
  * opaque type, internal to libvmemcache
  */
 typedef struct vmemcache VMEMcache;
+typedef struct vmemcache_config VMEMconfig;
 
 enum vmemcache_replacement_policy {
 	VMEMCACHE_REPLACEMENT_NONE,
@@ -114,6 +115,14 @@ typedef void vmemcache_on_evict(VMEMcache *cache,
 
 typedef void vmemcache_on_miss(VMEMcache *cache,
 	const void *key, size_t key_size, void *arg);
+
+VMEMconfig *vmemcache_config_new(void);
+void vmemcache_config_delete(VMEMconfig *cfg);
+
+void vmemcache_config_set_eviction_policy(VMEMconfig *cfg,
+	enum vmemcache_replacement_policy repl_p);
+void vmemcache_config_set_size(VMEMconfig *cfg, size_t size);
+void vmemcache_config_set_extent_size(VMEMconfig *cfg, size_t extent_size);
 
 #ifndef _WIN32
 VMEMcache *vmemcache_new(const char *path, size_t max_size, size_t extent_size,

--- a/src/libvmemcache.map
+++ b/src/libvmemcache.map
@@ -34,6 +34,11 @@
 #
 LIBVMEMCACHE_1.0 {
 	global:
+		vmemcache_config_new;
+		vmemcache_config_delete;
+		vmemcache_config_set_eviction_policy;
+		vmemcache_config_set_size;
+		vmemcache_config_set_extent_size;
 		vmemcache_new;
 		vmemcache_delete;
 		vmemcache_put;

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -62,6 +62,67 @@ static __thread struct {
 } get_req = { 0 };
 
 /*
+ * Default config.
+ */
+static VMEMconfig defconfig = {
+	.size = 0,
+	.max_size = 0,		/* same as size, infinite if not set */
+	.extent_size = 256,
+	.repl_p = VMEMCACHE_REPLACEMENT_LRU,
+};
+
+
+/*
+ * vmemcache_config_new -- allocate and init a config
+ */
+VMEMconfig *
+vmemcache_config_new(void)
+{
+	VMEMconfig *cfg = Malloc(sizeof(VMEMconfig));
+	if (cfg)
+		*cfg = defconfig;
+
+	return cfg;
+}
+
+/*
+ * vmemcache_config_delete -- free a config
+ */
+void
+vmemcache_config_delete(VMEMconfig *cfg)
+{
+	Free(cfg);
+}
+
+/*
+ * vmemcache_config_set_eviction_policy
+ */
+void
+vmemcache_config_set_eviction_policy(VMEMconfig *cfg,
+	enum vmemcache_replacement_policy repl_p)
+{
+	cfg->repl_p = repl_p;
+}
+
+/*
+ * vmemcache_config_set_size
+ */
+void
+vmemcache_config_set_size(VMEMconfig *cfg, size_t size)
+{
+	cfg->size = size;
+}
+
+/*
+ * vmemcache_config_set_extent_size
+ */
+void
+vmemcache_config_set_extent_size(VMEMconfig *cfg, size_t extent_size)
+{
+	cfg->extent_size = extent_size;
+}
+
+/*
  * vmemcache_newU -- (internal) create a vmemcache
  */
 #ifndef _WIN32

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -54,6 +54,13 @@ extern "C" {
 struct index;
 struct repl_p;
 
+struct vmemcache_config {
+	size_t size;			/* initial size of the cache */
+	size_t max_size;		/* never expand above this */
+	size_t extent_size;		/* allocation block size */
+	enum vmemcache_replacement_policy repl_p;
+};
+
 struct vmemcache {
 	void *addr;			/* mapping address */
 	size_t size;			/* mapping size */

--- a/tests/example.c
+++ b/tests/example.c
@@ -60,8 +60,7 @@ get(const char *key)
 int
 main()
 {
-	cache = vmemcache_new("/tmp", VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				VMEMCACHE_REPLACEMENT_LRU);
+	cache = vmemcache_new("/tmp", NULL);
 	if (cache == NULL) {
 		fprintf(stderr, "error: vmemcache_new: %s\n",
 				vmemcache_errormsg());

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -255,10 +255,10 @@ test_new_delete(const char *dir, const char *file,
 	vmemcache_delete(cache);
 
 	/* TEST #3 - extent_size == 0 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, 0,
+	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, 1,
 				replacement_policy);
 	if (cache != NULL)
-		UT_FATAL("vmemcache_new did not fail with extent_size == 0");
+		UT_FATAL("vmemcache_new did not fail with extent_size == 1");
 
 	/* TEST #4 - extent_size == -1 */
 	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, (size_t)-1,
@@ -288,11 +288,11 @@ test_new_delete(const char *dir, const char *file,
 			"vmemcache_new did not fail with size == VMEMCACHE_MIN_POOL - 1");
 
 	/* TEST #8 - size == 0 */
-	cache = vmemcache_new(dir, 0, VMEMCACHE_MIN_EXTENT,
+	cache = vmemcache_new(dir, 1, VMEMCACHE_MIN_EXTENT,
 				replacement_policy);
 	if (cache != NULL)
 		UT_FATAL(
-			"vmemcache_new did not fail with size == 0");
+			"vmemcache_new did not fail with size == 1");
 
 	/* TEST #9 - size == -1 */
 	cache = vmemcache_new(dir, (size_t)-1, VMEMCACHE_MIN_EXTENT,

--- a/tests/vmemcache_test_heap_usage.c
+++ b/tests/vmemcache_test_heap_usage.c
@@ -195,9 +195,12 @@ test_heap_usage(const char *dir, heap_usage *usage)
 {
 	int ret = 0;
 
+	VMEMconfig *cfg = vmemcache_config_new();
+	vmemcache_config_set_size(cfg, VMEMCACHE_MIN_POOL);
+	vmemcache_config_set_extent_size(cfg, VMEMCACHE_MIN_EXTENT);
 	VMEMcache *cache;
-	TRACE_HEAP(cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-		VMEMCACHE_MIN_EXTENT, VMEMCACHE_REPLACEMENT_LRU));
+	TRACE_HEAP(cache = vmemcache_new(dir, cfg));
+	vmemcache_config_delete(cfg);
 	if (cache == NULL)
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 

--- a/tests/vmemcache_test_mt.c
+++ b/tests/vmemcache_test_mt.c
@@ -515,9 +515,11 @@ main(int argc, char *argv[])
 
 	srand(seed);
 
-	VMEMcache *cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-						VMEMCACHE_MIN_EXTENT,
-						VMEMCACHE_REPLACEMENT_LRU);
+	VMEMconfig *cfg = vmemcache_config_new();
+	vmemcache_config_set_size(cfg, VMEMCACHE_MIN_POOL); /* limit the size */
+
+	VMEMcache *cache = vmemcache_new(dir, cfg);
+	vmemcache_config_delete(cfg);
 	if (cache == NULL)
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), dir);
 

--- a/tests/vmemcache_test_utilization.c
+++ b/tests/vmemcache_test_utilization.c
@@ -304,7 +304,12 @@ main(int argc, char **argv)
 {
 	test_params p = parse_args(argc, argv);
 
-	VMEMcache *vc = vmemcache_new(p.dir, p.pool_size, p.extent_size, 1);
+	VMEMconfig *cfg = vmemcache_config_new();
+	vmemcache_config_set_size(cfg, p.pool_size);
+	vmemcache_config_set_extent_size(cfg, p.extent_size);
+	vmemcache_config_set_eviction_policy(cfg, VMEMCACHE_REPLACEMENT_LRU);
+	VMEMcache *vc = vmemcache_new(p.dir, cfg);
+	vmemcache_config_delete(cfg);
 	if (vc == NULL)
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), p.dir);
 


### PR DESCRIPTION
Instead of passing parameters as arguments to the function, they're a part of "VMEMconfig" struct.  It's initialized either via `vmemcache_config_init(&cfg)` or statically via `= VMEMCACHE_CONFIG_EMPTY`.  If you're ok with defaults (LRU, ~infinitely growable~ 1MB size, extent 256 bytes), no config is needed at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/189)
<!-- Reviewable:end -->
