### PR TITLE
new creation API: separate _open() step

### DIFF
--- a/benchmarks/bench_micro.c
+++ b/benchmarks/bench_micro.c
@@ -71,11 +71,11 @@ struct context {
  * bench_init -- (internal) initialize benchmark
  */
 static VMEMcache *
-bench_init(const char *path, size_t max_size, size_t extent_size,
+bench_init(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_repl_p replacement_policy,
 		unsigned n_threads, struct context *ctx)
 {
-	VMEMcache *cache = vmemcache_new(path, max_size, extent_size,
+	VMEMcache *cache = vmemcache_new(path, size, extent_size,
 						replacement_policy);
 	if (cache == NULL)
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), path);
@@ -196,12 +196,12 @@ print_bench_results(const char *op_name, unsigned n_threads,
  * run_test_put -- (internal) run test for vmemcache_put()
  */
 static void
-run_bench_put(const char *path, size_t max_size, size_t extent_size,
+run_bench_put(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_repl_p replacement_policy,
 		unsigned n_threads, os_thread_t *threads,
 		unsigned ops_count, struct context *ctx)
 {
-	VMEMcache *cache = bench_init(path, max_size, extent_size,
+	VMEMcache *cache = bench_init(path, size, extent_size,
 					replacement_policy, n_threads, ctx);
 
 	unsigned ops_per_thread = ops_count / n_threads;
@@ -237,12 +237,12 @@ on_evict_cb(VMEMcache *cache, const void *key, size_t key_size, void *arg)
  * run_bench_get -- (internal) run test for vmemcache_get()
  */
 static void
-run_bench_get(const char *path, size_t max_size, size_t extent_size,
+run_bench_get(const char *path, size_t size, size_t extent_size,
 		enum vmemcache_repl_p replacement_policy,
 		unsigned n_threads, os_thread_t *threads,
 		unsigned ops_count, struct context *ctx)
 {
-	VMEMcache *cache = bench_init(path, max_size, extent_size,
+	VMEMcache *cache = bench_init(path, size, extent_size,
 					replacement_policy, n_threads, ctx);
 
 	int cache_is_full = 0;
@@ -279,13 +279,13 @@ run_bench_get(const char *path, size_t max_size, size_t extent_size,
 }
 
 #define USAGE_STRING \
-"usage: %s <directory> [benchmark] [threads] [ops_count] [cache_max_size] [cache_extent_size] [nbuffs] [min_size] [max_size] [seed]\n"\
+"usage: %s <directory> [benchmark] [threads] [ops_count] [cache_size] [cache_extent_size] [nbuffs] [min_size] [max_size] [seed]\n"\
 "       [benchmark] - can be: all (default), put or get\n"\
 "       Default values of parameters:\n"\
 "       - benchmark           = all (put and get)\n"\
 "       - threads             = %u\n"\
 "       - ops_count           = %u\n"\
-"       - cache_max_size      = %u\n"\
+"       - cache_size          = %u\n"\
 "       - cache_extent_size   = %u\n"\
 "       - nbuffs              = %u\n"\
 "       - min_size            = %u\n"\
@@ -302,7 +302,7 @@ main(int argc, char *argv[])
 	unsigned benchmark = BENCH_ALL;
 	unsigned n_threads = 10;
 	unsigned ops_count = 100000;
-	unsigned cache_max_size = VMEMCACHE_MIN_POOL;
+	unsigned cache_size = VMEMCACHE_MIN_POOL;
 	unsigned cache_extent_size = VMEMCACHE_MIN_EXTENT;
 	unsigned nbuffs = 10;
 	unsigned min_size = 128;
@@ -310,7 +310,7 @@ main(int argc, char *argv[])
 
 	if (argc < 2 || argc > 11) {
 		fprintf(stderr, USAGE_STRING, argv[0], n_threads, ops_count,
-			cache_max_size, cache_extent_size,
+			cache_size, cache_extent_size,
 			nbuffs, min_size, max_size);
 		exit(-1);
 	}
@@ -340,9 +340,9 @@ main(int argc, char *argv[])
 		UT_FATAL("incorrect value of ops_count: %s", argv[4]);
 
 	if (argc >= 6 &&
-	    (str_to_unsigned(argv[5], &cache_max_size) ||
-			    cache_max_size < VMEMCACHE_MIN_POOL))
-		UT_FATAL("incorrect value of cache_max_size: %s", argv[5]);
+	    (str_to_unsigned(argv[5], &cache_size) ||
+			    cache_size < VMEMCACHE_MIN_POOL))
+		UT_FATAL("incorrect value of cache_size: %s", argv[5]);
 
 	if (argc >= 7 &&
 	    (str_to_unsigned(argv[6], &cache_extent_size) ||
@@ -373,7 +373,7 @@ main(int argc, char *argv[])
 	printf("   directory           : %s\n", dir);
 	printf("   n_threads           : %u\n", n_threads);
 	printf("   ops_count           : %u\n", ops_count);
-	printf("   cache_max_size      : %u\n", cache_max_size);
+	printf("   cache_size          : %u\n", cache_size);
 	printf("   cache_extent_size   : %u\n", cache_extent_size);
 	printf("   nbuffs              : %u\n", nbuffs);
 	printf("   min_size            : %u\n", min_size);
@@ -414,12 +414,12 @@ main(int argc, char *argv[])
 		UT_FATAL("out of memory");
 
 	if (benchmark & BENCH_PUT)
-		run_bench_put(dir, cache_max_size, cache_extent_size,
+		run_bench_put(dir, cache_size, cache_extent_size,
 				VMEMCACHE_REPLACEMENT_LRU,
 				n_threads, threads, ops_count, ctx);
 
 	if (benchmark & BENCH_GET)
-		run_bench_get(dir, cache_max_size, cache_extent_size,
+		run_bench_get(dir, cache_size, cache_extent_size,
 				VMEMCACHE_REPLACEMENT_LRU,
 				n_threads, threads, ops_count, ctx);
 

--- a/benchmarks/bench_simul.c
+++ b/benchmarks/bench_simul.c
@@ -603,10 +603,13 @@ static void run_bench()
 	os_mutex_init(&ready.mutex);
 	ready.wanted = n_threads;
 
-	cache = vmemcache_new(dir, cache_size, cache_extent_size,
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, cache_size);
+	vmemcache_set_extent_size(cache, cache_extent_size);
+	vmemcache_set_eviction_policy(cache,
 		(enum vmemcache_repl_p)repl_policy);
-	if (!cache)
-		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), dir);
+	if (vmemcache_add(cache, dir))
+		UT_FATAL("vmemcache_add: %s (%s)", vmemcache_errormsg(), dir);
 
 	if (latency_samples) {
 		latencies = malloc((ops_count * n_threads + 1) *

--- a/src/libvmemcache.h
+++ b/src/libvmemcache.h
@@ -115,16 +115,19 @@ typedef void vmemcache_on_evict(VMEMcache *cache,
 typedef void vmemcache_on_miss(VMEMcache *cache,
 	const void *key, size_t key_size, void *arg);
 
+VMEMcache *
+vmemcache_new(void);
+
+int vmemcache_set_eviction_policy(VMEMcache *cache,
+	enum vmemcache_repl_p repl_p);
+int vmemcache_set_size(VMEMcache *cache, size_t size);
+int vmemcache_set_extent_size(VMEMcache *cache, size_t extent_size);
+
 #ifndef _WIN32
-VMEMcache *vmemcache_new(const char *path, size_t max_size, size_t extent_size,
-		enum vmemcache_repl_p replacement_policy);
+int vmemcache_add(VMEMcache *cache, const char *path);
 #else
-VMEMcache *vmemcache_newU(const char *path, size_t max_size,
-		size_t extent_size,
-		enum vmemcache_repl_p replacement_policy);
-VMEMcache *vmemcache_newW(const wchar_t *path, size_t max_size,
-		size_t extent_size,
-		enum vmemcache_repl_p replacement_policy);
+int vmemcache_addU(VMEMcache *cache, const char *path);
+int vmemcache_addW(VMEMcache *cache, const wchar_t *path);
 #endif
 
 void vmemcache_delete(VMEMcache *cache);

--- a/src/libvmemcache.map
+++ b/src/libvmemcache.map
@@ -36,6 +36,10 @@ LIBVMEMCACHE_1.0 {
 	global:
 		vmemcache_new;
 		vmemcache_delete;
+		vmemcache_set_eviction_policy;
+		vmemcache_set_size;
+		vmemcache_set_extent_size;
+		vmemcache_add;
 		vmemcache_put;
 		vmemcache_get;
 		vmemcache_evict;

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -62,38 +62,12 @@ static __thread struct {
 } get_req = { 0 };
 
 /*
- * vmemcache_newU -- (internal) create a vmemcache
+ * vmemcache_new -- create a vmemcache
  */
-#ifndef _WIN32
-static inline
-#endif
 VMEMcache *
-vmemcache_newU(const char *dir, size_t max_size, size_t extent_size,
-		enum vmemcache_repl_p replacement_policy)
+vmemcache_new()
 {
-	LOG(3, "dir %s max_size %zu extent_size %zu replacement_policy %d",
-		dir, max_size, extent_size, replacement_policy);
-
-	if (max_size < VMEMCACHE_MIN_POOL) {
-		ERR("size %zu smaller than %zu", max_size, VMEMCACHE_MIN_POOL);
-		errno = EINVAL;
-		return NULL;
-	}
-
-	if (extent_size < VMEMCACHE_MIN_EXTENT) {
-		ERR("extent size %zu smaller than %zu bytes",
-			extent_size, VMEMCACHE_MIN_EXTENT);
-		errno = EINVAL;
-		return NULL;
-	}
-
-	if (extent_size > max_size) {
-		ERR(
-			"extent size %zu larger than maximum file size: %zu bytes",
-			extent_size, max_size);
-		errno = EINVAL;
-		return NULL;
-	}
+	LOG(3, NULL);
 
 	VMEMcache *cache = Zalloc(sizeof(VMEMcache));
 	if (cache == NULL) {
@@ -101,45 +75,158 @@ vmemcache_newU(const char *dir, size_t max_size, size_t extent_size,
 		return NULL;
 	}
 
+	cache->repl_p = VMEMCACHE_REPLACEMENT_LRU;
+	cache->extent_size = VMEMCACHE_MIN_EXTENT;
+
+	return cache;
+}
+
+/*
+ * vmemcache_set_eviction_policy
+ */
+int
+vmemcache_set_eviction_policy(VMEMcache *cache,
+	enum vmemcache_repl_p repl_p)
+{
+	LOG(3, "cache %p eviction policy %d", cache, repl_p);
+
+	if (cache->ready) {
+		ERR("cache already in use");
+		errno =  EALREADY;
+		return -1;
+	}
+
+	cache->repl_p = repl_p;
+	return 0;
+}
+
+/*
+ * vmemcache_set_size
+ */
+int
+vmemcache_set_size(VMEMcache *cache, size_t size)
+{
+	LOG(3, "cache %p size %zu", cache, size);
+
+	/* TODO: allow growing this way */
+	if (cache->ready) {
+		ERR("cache already in use");
+		errno =  EALREADY;
+		return -1;
+	}
+
+	if (size < VMEMCACHE_MIN_POOL) {
+		ERR("size %zu smaller than %zu", size, VMEMCACHE_MIN_POOL);
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (size >= (1ULL << 56)) {
+		ERR("implausible large size %zu", size);
+		errno = EINVAL;
+		return -1;
+	}
+
+	cache->size = size;
+	return 0;
+}
+
+/*
+ * vmemcache_set_extent_size
+ */
+int
+vmemcache_set_extent_size(VMEMcache *cache, size_t extent_size)
+{
+	LOG(3, "cache %p extent_size %zu", cache, extent_size);
+
+	if (cache->ready) {
+		ERR("cache already in use");
+		errno =  EALREADY;
+		return -1;
+	}
+
+	if (extent_size < VMEMCACHE_MIN_EXTENT) {
+		ERR("extent size %zu smaller than %zu bytes",
+			extent_size, VMEMCACHE_MIN_EXTENT);
+		errno = EINVAL;
+		return -1;
+	}
+
+	cache->extent_size = extent_size;
+	return 0;
+}
+
+/*
+ * vmemcache_addU -- (internal) open the backing file
+ */
+#ifndef _WIN32
+static inline
+#endif
+int
+vmemcache_addU(VMEMcache *cache, const char *dir)
+{
+	LOG(3, "cache %p dir %s", cache, dir);
+
+	size_t size = cache->size;
+
+	if (size && cache->extent_size > size) {
+		ERR(
+			"extent size %zu larger than cache size: %zu bytes",
+			cache->extent_size, size);
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (size && size < VMEMCACHE_MIN_POOL) {
+		ERR("cache size %zu smaller than %zu", size,
+			VMEMCACHE_MIN_POOL);
+		errno = EINVAL;
+		return -1;
+	}
+
 	enum file_type type = util_file_get_type(dir);
 	if (type == OTHER_ERROR) {
 		LOG(1, "checking file type failed");
-		goto error_free_cache;
+		return -1;
 	}
 
 	if (type == TYPE_DEVDAX) {
 		const char *devdax = dir;
-		ssize_t size = util_file_get_size(devdax);
-		if (size < 0) {
+		ssize_t dax_size = util_file_get_size(devdax);
+		if (dax_size < 0) {
 			LOG(1, "cannot determine file length \"%s\"", devdax);
-			goto error_free_cache;
+			return -1;
 		}
 
-		if (max_size != 0 && max_size > (size_t)size) {
+		if (size != 0 && size > (size_t)dax_size) {
 			ERR(
 				"error: maximum cache size (%zu) is bigger than the size of the DAX device (%zi)",
-				max_size, size);
+				size, dax_size);
 			errno = EINVAL;
-			goto error_free_cache;
+			return -1;
 		}
 
-		if (max_size == 0) {
-			cache->size = (size_t)size;
+		if (size == 0) {
+			cache->size = (size_t)dax_size;
 		} else {
-			cache->size = roundup(max_size, Mmap_align);
-			if (cache->size > (size_t)size)
-				cache->size = (size_t)size;
+			cache->size = roundup(size, Mmap_align);
+			if (cache->size > (size_t)dax_size)
+				cache->size = (size_t)dax_size;
 		}
 
 		cache->addr = util_file_map_whole(devdax);
 		if (cache->addr == NULL) {
 			LOG(1, "mapping of whole DAX device failed");
-			goto error_free_cache;
+			return -1;
 		}
 
 	} else {
 		/* silently enforce multiple of mapping alignment */
-		cache->size = roundup(max_size, Mmap_align);
+		cache->size = roundup(cache->size, Mmap_align);
+
+		/* if not set, start with the default */
+		if (!cache->size)
+			cache->size = VMEMCACHE_MIN_POOL;
 
 		/*
 		 * XXX: file should be mapped on-demand during allocation,
@@ -148,12 +235,12 @@ vmemcache_newU(const char *dir, size_t max_size, size_t extent_size,
 		cache->addr = util_map_tmpfile(dir, cache->size, 4 * MEGABYTE);
 		if (cache->addr == NULL) {
 			LOG(1, "mapping of a temporary file failed");
-			goto error_free_cache;
+			return -1;
 		}
 	}
 
 	cache->heap = vmcache_heap_create(cache->addr, cache->size,
-						extent_size);
+						cache->extent_size);
 	if (cache->heap == NULL) {
 		LOG(1, "heap initialization failed");
 		goto error_unmap;
@@ -165,14 +252,15 @@ vmemcache_newU(const char *dir, size_t max_size, size_t extent_size,
 		goto error_destroy_heap;
 	}
 
-	cache->repl_p = replacement_policy;
 	cache->repl = repl_p_init(cache->repl_p);
 	if (cache->repl == NULL) {
 		LOG(1, "replacement policy initialization failed");
 		goto error_destroy_index;
 	}
 
-	return cache;
+	cache->ready = 1;
+
+	return 0;
 
 error_destroy_index:
 	vmcache_index_delete(cache->index, vmemcache_delete_entry_cb);
@@ -180,9 +268,7 @@ error_destroy_heap:
 	vmcache_heap_destroy(cache->heap);
 error_unmap:
 	util_unmap(cache->addr, cache->size);
-error_free_cache:
-	Free(cache);
-	return NULL;
+	return -1;
 }
 
 /*
@@ -203,10 +289,12 @@ vmemcache_delete(VMEMcache *cache)
 {
 	LOG(3, "cache %p", cache);
 
-	repl_p_destroy(cache->repl);
-	vmcache_index_delete(cache->index, vmemcache_delete_entry_cb);
-	vmcache_heap_destroy(cache->heap);
-	util_unmap(cache->addr, cache->size);
+	if (cache->ready) {
+		repl_p_destroy(cache->repl);
+		vmcache_index_delete(cache->index, vmemcache_delete_entry_cb);
+		vmcache_heap_destroy(cache->heap);
+		util_unmap(cache->addr, cache->size);
+	}
 	Free(cache);
 }
 
@@ -699,29 +787,25 @@ vmemcache_bench_set(VMEMcache *cache, enum vmemcache_bench_cfg cfg, size_t val)
 
 #ifndef _WIN32
 /*
- * vmemcache_new -- create a vmemcache
+ * vmemcache_add -- add a backing file to vmemcache
  */
-VMEMcache *
-vmemcache_new(const char *path, size_t max_size, size_t extent_size,
-		enum vmemcache_repl_p replacement_policy)
+int
+vmemcache_add(VMEMcache *cache, const char *path)
 {
-	return vmemcache_newU(path, max_size, extent_size,
-				replacement_policy);
+	return vmemcache_addU(cache, path);
 }
 #else
 /*
- * vmemcache_newW -- create a vmemcache
+ * vmemcache_addW -- add a backing file to vmemcache, wchar version
  */
-VMEMcache *
-vmemcache_newW(const wchar_t *path, size_t max_size, size_t extent_size,
-		enum vmemcache_repl_p replacement_policy)
+int
+vmemcache_addW(VMEMcache *cache, const wchar_t *path)
 {
 	char *upath = util_toUTF8(path);
 	if (upath == NULL)
-		return NULL;
+		return -1;
 
-	VMEMcache *ret = vmemcache_newU(upath, path, max_size, extent_size,
-					replacement_policy);
+	int ret = vmemcache_addU(cache, upath);
 
 	util_free_UTF8(upath);
 	return ret;

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -264,10 +264,13 @@ vmemcache_addU(VMEMcache *cache, const char *dir)
 
 error_destroy_index:
 	vmcache_index_delete(cache->index, vmemcache_delete_entry_cb);
+	cache->index = NULL;
 error_destroy_heap:
 	vmcache_heap_destroy(cache->heap);
+	cache->heap = NULL;
 error_unmap:
 	util_unmap(cache->addr, cache->size);
+	cache->addr = NULL;
 	return -1;
 }
 

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -57,6 +57,7 @@ struct repl_p;
 struct vmemcache {
 	void *addr;			/* mapping address */
 	size_t size;			/* mapping size */
+	size_t extent_size;		/* heap granularity */
 	struct heap *heap;		/* heap address */
 	struct index *index;		/* indexing structure */
 	enum vmemcache_repl_p repl_p;	/* replacement policy */
@@ -65,6 +66,7 @@ struct vmemcache {
 	void *arg_evict;		/* argument for callback on evict */
 	vmemcache_on_miss *on_miss;	/* callback on miss */
 	void *arg_miss;			/* argument for callback on miss */
+	unsigned ready:1;		/* is the cache ready for use? */
 	unsigned index_only:1;		/* bench: disable repl+alloc */
 	unsigned no_alloc:1;		/* bench: disable allocations */
 	unsigned no_memcpy:1;		/* bench: don't copy actual data */

--- a/tests/example.c
+++ b/tests/example.c
@@ -60,12 +60,11 @@ get(const char *key)
 int
 main()
 {
-	cache = vmemcache_new("/tmp", VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				VMEMCACHE_REPLACEMENT_LRU);
-	if (cache == NULL) {
-		fprintf(stderr, "error: vmemcache_new: %s\n",
+	cache = vmemcache_new();
+	if (vmemcache_add(cache, "/tmp")) {
+		fprintf(stderr, "error: vmemcache_add: %s\n",
 				vmemcache_errormsg());
-		return -1;
+		return 1;
 	}
 
 	/* Query a non-existent key. */

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -254,9 +254,9 @@ test_new_delete(const char *dir, const char *file, enum vmemcache_repl_p repl_p)
 	vmemcache_delete(cache);
 
 	/* TEST #3 - extent_size == 0 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, 0, repl_p);
+	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, 1, repl_p);
 	if (cache != NULL)
-		UT_FATAL("vmemcache_new did not fail with extent_size == 0");
+		UT_FATAL("vmemcache_new did not fail with extent_size == 1");
 
 	/* TEST #4 - extent_size == -1 */
 	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, (size_t)-1, repl_p);
@@ -285,10 +285,10 @@ test_new_delete(const char *dir, const char *file, enum vmemcache_repl_p repl_p)
 			"vmemcache_new did not fail with size == VMEMCACHE_MIN_POOL - 1");
 
 	/* TEST #8 - size == 0 */
-	cache = vmemcache_new(dir, 0, VMEMCACHE_MIN_EXTENT, repl_p);
+	cache = vmemcache_new(dir, 1, VMEMCACHE_MIN_EXTENT, repl_p);
 	if (cache != NULL)
 		UT_FATAL(
-			"vmemcache_new did not fail with size == 0");
+			"vmemcache_new did not fail with size == 1");
 
 	/* TEST #9 - size == -1 */
 	cache = vmemcache_new(dir, (size_t)-1, VMEMCACHE_MIN_EXTENT, repl_p);

--- a/tests/vmemcache_test_basic.c
+++ b/tests/vmemcache_test_basic.c
@@ -238,87 +238,112 @@ test_new_delete(const char *dir, const char *file, enum vmemcache_repl_p repl_p)
 	VMEMcache *cache;
 
 	/* TEST #1 - minimum values of max_size and extent_size */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				repl_p);
-	if (cache == NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	vmemcache_delete(cache);
 
 	/* TEST #2 - extent_size = max_size = VMEMCACHE_MIN_POOL */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_POOL,
-				repl_p);
-	if (cache == NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	vmemcache_delete(cache);
 
-	/* TEST #3 - extent_size == 0 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, 1, repl_p);
-	if (cache != NULL)
-		UT_FATAL("vmemcache_new did not fail with extent_size == 1");
+	/* TEST #3 - extent_size == 1 */
+	cache = vmemcache_new();
+	if (!vmemcache_set_extent_size(cache, 1))
+		UT_FATAL(
+			"vmemcache_set_extent_size did not fail with extent_size == 1");
+
+	vmemcache_delete(cache);
 
 	/* TEST #4 - extent_size == -1 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, (size_t)-1, repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	if (!vmemcache_set_extent_size(cache, (size_t)-1) &&
+		!vmemcache_add(cache, dir)) {
 		UT_FATAL("vmemcache_new did not fail with extent_size == -1");
+	}
+	vmemcache_delete(cache);
 
 	/* TEST #5 - extent_size == VMEMCACHE_MIN_EXTENT - 1 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT - 1,
-				repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	if (!vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT - 1))
 		UT_FATAL(
 			"vmemcache_new did not fail with extent_size == VMEMCACHE_MIN_EXTENT - 1");
+	vmemcache_delete(cache);
 
 	/* TEST #6 - extent_size == max_size + 1 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_POOL + 1,
-				repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	if (!vmemcache_set_extent_size(cache, VMEMCACHE_MIN_POOL + 1) &&
+		!vmemcache_add(cache, dir)) {
 		UT_FATAL(
 			"vmemcache_new did not fail with extent_size == max_size + 1");
+	}
+	vmemcache_delete(cache);
 
 	/* TEST #7 - size == VMEMCACHE_MIN_POOL - 1 */
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL - 1, VMEMCACHE_MIN_EXTENT,
-				repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	if (!vmemcache_set_size(cache, VMEMCACHE_MIN_POOL - 1))
 		UT_FATAL(
 			"vmemcache_new did not fail with size == VMEMCACHE_MIN_POOL - 1");
+	vmemcache_delete(cache);
 
-	/* TEST #8 - size == 0 */
-	cache = vmemcache_new(dir, 1, VMEMCACHE_MIN_EXTENT, repl_p);
-	if (cache != NULL)
+	/* TEST #8 - size == 1 */
+	cache = vmemcache_new();
+	if (!vmemcache_set_size(cache, 1))
 		UT_FATAL(
 			"vmemcache_new did not fail with size == 1");
+	vmemcache_delete(cache);
 
 	/* TEST #9 - size == -1 */
-	cache = vmemcache_new(dir, (size_t)-1, VMEMCACHE_MIN_EXTENT, repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	if (!vmemcache_set_size(cache, (size_t)-1))
 		UT_FATAL(
 			"vmemcache_new did not fail with size == -1");
+	vmemcache_delete(cache);
 
 	/* TEST #10 - not a directory, but a file */
-	cache = vmemcache_new(file, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (!vmemcache_add(cache, file))
 		UT_FATAL(
 			"vmemcache_new did not fail with a file instead of a directory");
+	vmemcache_delete(cache);
 
 	/* TEST #11 - NULL directory path */
-	cache = vmemcache_new(NULL, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				repl_p);
-	if (cache != NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (!vmemcache_add(cache, NULL))
 		UT_FATAL(
 			"vmemcache_new did not fail with a NULL directory path");
+	vmemcache_delete(cache);
 
 	/* TEST #12 - nonexistent directory path */
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
 	char nonexistent[PATH_MAX];
 	strcpy(nonexistent, dir);
 	strcat(nonexistent, "/nonexistent_dir");
-	cache = vmemcache_new(nonexistent, VMEMCACHE_MIN_POOL,
-				VMEMCACHE_MIN_EXTENT, repl_p);
-	if (cache != NULL)
+	if (!vmemcache_add(cache, nonexistent))
 		UT_FATAL(
 			"vmemcache_new did not fail with a nonexistent directory path");
+	vmemcache_delete(cache);
 }
 
 /*
@@ -327,11 +352,11 @@ test_new_delete(const char *dir, const char *file, enum vmemcache_repl_p repl_p)
 static void
 test_put_get_evict(const char *dir, enum vmemcache_repl_p repl_p)
 {
-	VMEMcache *cache;
-
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_EXTENT,
-				repl_p);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	const char *key = "KEY";
@@ -451,9 +476,11 @@ test_evict(const char *dir, enum vmemcache_repl_p repl_p)
 		char value[VSIZE];
 	} data[DNUM];
 
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_EXTENT,
-				repl_p);
-	if (cache == NULL)
+	cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	vmemcache_callback_on_evict(cache, on_evict_test_evict_cb, &ctx);
@@ -628,7 +655,6 @@ test_memory_leaks(const char *dir, int key_gt_1K,
 			enum vmemcache_repl_p repl_p,
 			unsigned seed)
 {
-	VMEMcache *cache;
 	char *vbuf;
 	char *get_buf;
 	size_t size;
@@ -646,9 +672,11 @@ test_memory_leaks(const char *dir, int key_gt_1K,
 	size_t min_size = VMEMCACHE_MIN_EXTENT / 2;
 	size_t max_size = VMEMCACHE_MIN_POOL / 16;
 
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				repl_p);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	vmemcache_callback_on_evict(cache, on_evict_test_memory_leaks_cb,
@@ -734,7 +762,6 @@ test_memory_leaks(const char *dir, int key_gt_1K,
 static void
 test_merge_allocations(const char *dir, enum vmemcache_repl_p repl_p)
 {
-	VMEMcache *cache;
 	ssize_t ret;
 
 #define N_KEYS 5
@@ -751,9 +778,11 @@ test_merge_allocations(const char *dir, enum vmemcache_repl_p repl_p)
 	size_t key_size = strlen(key[0]) + 1;
 	size_t val_size = strlen(value) + 1;
 
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_EXTENT,
-				repl_p);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_EXTENT);
+	vmemcache_set_eviction_policy(cache, repl_p);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	verify_stat_entries(cache, 0);
@@ -831,9 +860,11 @@ test_put_in_evict(const char *dir, enum vmemcache_repl_p policy, unsigned seed)
 
 	srand(seed);
 
-	VMEMcache *cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-		VMEMCACHE_MIN_EXTENT, policy);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, policy);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	struct put_evict_cb ctx =
@@ -869,9 +900,10 @@ test_put_in_evict(const char *dir, enum vmemcache_repl_p policy, unsigned seed)
 static void
 test_vmemcache_get_stat(const char *dir)
 {
-	VMEMcache *cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-		VMEMCACHE_MIN_EXTENT, VMEMCACHE_REPLACEMENT_LRU);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	/* TEST #1 - stat with invalid size */
@@ -1003,7 +1035,6 @@ on_evict_test_data_integrity(VMEMcache *cache, const void *key, size_t key_size,
 static void
 test_data_integrity(const char *dir, unsigned seed)
 {
-	VMEMcache *cache;
 	size_t size;
 	size_t offset;
 	int ret;
@@ -1034,9 +1065,10 @@ test_data_integrity(const char *dir, unsigned seed)
 
 	struct ctx_di_cb ctx = {values_buffer, get_buffer, max_size, 0};
 
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				VMEMCACHE_REPLACEMENT_LRU);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	vmemcache_callback_on_evict(cache, on_evict_test_data_integrity, &ctx);
@@ -1095,11 +1127,11 @@ test_data_integrity(const char *dir, unsigned seed)
 static void
 test_get_with_offset(const char *dir)
 {
-	VMEMcache *cache;
+	VMEMcache *cache = vmemcache_new();
 
-	cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL, VMEMCACHE_MIN_EXTENT,
-				VMEMCACHE_REPLACEMENT_LRU);
-	if (cache == NULL)
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
 
 	char key[KSIZE];
@@ -1227,10 +1259,12 @@ test_offsets(const char *dir, enum vmemcache_repl_p policy)
 	};
 	size_t n_tcs = sizeof(tcs) / sizeof(struct offset_tc);
 
-	VMEMcache *cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-		VMEMCACHE_MIN_EXTENT, policy);
-	if (cache == NULL)
-		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	vmemcache_set_eviction_policy(cache, policy);
+	if (vmemcache_add(cache, dir))
+		UT_FATAL("vmemcache_add: %s", vmemcache_errormsg());
 
 	const char *key = "KEY";
 	size_t ksize = strlen(key) + 1;

--- a/tests/vmemcache_test_heap_usage.c
+++ b/tests/vmemcache_test_heap_usage.c
@@ -196,10 +196,14 @@ test_heap_usage(const char *dir, heap_usage *usage)
 	int ret = 0;
 
 	VMEMcache *cache;
-	TRACE_HEAP(cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-		VMEMCACHE_MIN_EXTENT, VMEMCACHE_REPLACEMENT_LRU));
+	TRACE_HEAP(cache = vmemcache_new());
 	if (cache == NULL)
 		UT_FATAL("vmemcache_new: %s", vmemcache_errormsg());
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL);
+	vmemcache_set_extent_size(cache, VMEMCACHE_MIN_EXTENT);
+	TRACE_HEAP(ret = vmemcache_add(cache, dir));
+	if (ret)
+		UT_FATAL("vmemcache_add: %s", vmemcache_errormsg());
 
 	TRACE_HEAP(vmemcache_callback_on_evict(cache, on_evict_cb, usage));
 

--- a/tests/vmemcache_test_mt.c
+++ b/tests/vmemcache_test_mt.c
@@ -588,10 +588,10 @@ main(int argc, char *argv[])
 
 	srand(seed);
 
-	VMEMcache *cache = vmemcache_new(dir, VMEMCACHE_MIN_POOL,
-						VMEMCACHE_MIN_EXTENT,
-						VMEMCACHE_REPLACEMENT_LRU);
-	if (cache == NULL)
+	VMEMcache *cache = vmemcache_new();
+	vmemcache_set_size(cache, VMEMCACHE_MIN_POOL); /* limit the size */
+
+	if (vmemcache_add(cache, dir))
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), dir);
 
 	struct buffers *buffs = calloc(nbuffs, sizeof(*buffs));

--- a/tests/vmemcache_test_utilization.c
+++ b/tests/vmemcache_test_utilization.c
@@ -304,8 +304,11 @@ main(int argc, char **argv)
 {
 	test_params p = parse_args(argc, argv);
 
-	VMEMcache *vc = vmemcache_new(p.dir, p.pool_size, p.extent_size, 1);
-	if (vc == NULL)
+	VMEMcache *vc = vmemcache_new();
+	vmemcache_set_size(vc, p.pool_size);
+	vmemcache_set_extent_size(vc, p.extent_size);
+	vmemcache_set_eviction_policy(vc, VMEMCACHE_REPLACEMENT_LRU);
+	if (vmemcache_add(vc, p.dir))
 		UT_FATAL("vmemcache_new: %s (%s)", vmemcache_errormsg(), p.dir);
 
 	int ret = put_until_timeout(vc, &p);


### PR DESCRIPTION
Marcin's version, which I like the most.

There's no separate "config" object — the cache gets configured, then opens a file.  This way, some parameters might remain settable at later stages.  Also, it may be possible to open multiple backing files for a single cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/197)
<!-- Reviewable:end -->
