### PR TITLE
test: fix possible null-pointer dereference in test_heap_usage

### DIFF
--- a/tests/vmemcache_test_heap_usage.c
+++ b/tests/vmemcache_test_heap_usage.c
@@ -205,7 +205,10 @@ test_heap_usage(const char *dir, heap_usage *usage)
 
 	size_t key = 0;
 	size_t vsize = 32;
+
 	char *value = malloc(vsize);
+	if (value == NULL)
+		UT_FATAL("out of memory");
 	memset(value, 'a', vsize - 1);
 	value[vsize - 1] = '\0';
 


### PR DESCRIPTION
It fixes Klocwork issue #399.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/198)
<!-- Reviewable:end -->
