### PR TITLE
keep data about index size in the shards

### DIFF
--- a/src/critnib.h
+++ b/src/critnib.h
@@ -56,7 +56,9 @@ struct critnib_node {
 struct critnib {
 	struct critnib_node *root;
 	os_rwlock_t lock;
+	size_t leaf_count; /* entries */
 	size_t node_count; /* internal nodes only */
+	size_t DRAM_usage; /* ... of leaves (nodes are constant-sized) */
 };
 
 struct cache_entry;

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -36,7 +36,6 @@
 
 #include <sys/mman.h>
 #include <errno.h>
-#include <malloc.h>
 
 #include "out.h"
 #include "file.h"
@@ -635,7 +634,7 @@ vmemcache_get_stat(VMEMcache *cache, enum vmemcache_statistic stat,
 		*val = cache->evict_count;
 		break;
 	case VMEMCACHE_STAT_ENTRIES:
-		*val = cache->put_count - cache->evict_count;
+		*val = vmemcache_entry_count(cache->index);
 		break;
 	case VMEMCACHE_STAT_DRAM_SIZE_USED:
 		*val = vmemcache_index_memory_usage(cache->index)

--- a/src/vmemcache.c
+++ b/src/vmemcache.c
@@ -323,7 +323,6 @@ put_index:
 					&entry->value.p_entry);
 	}
 
-	STAT_ADD(&cache->size_DRAM, malloc_usable_size(entry));
 	STAT_ADD(&cache->put_count, 1);
 
 	return 0;
@@ -414,8 +413,6 @@ vmemcache_entry_release(VMEMcache *cache, struct cache_entry *entry)
 	VALGRIND_ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(&entry->value.refcount);
 
 	vmcache_free(cache->heap, entry->value.extents);
-
-	STAT_SUB(&cache->size_DRAM, malloc_usable_size(entry));
 
 	Free(entry);
 }
@@ -641,8 +638,7 @@ vmemcache_get_stat(VMEMcache *cache, enum vmemcache_statistic stat,
 		*val = cache->put_count - cache->evict_count;
 		break;
 	case VMEMCACHE_STAT_DRAM_SIZE_USED:
-		*val = cache->size_DRAM
-			+ vmemcache_index_internal_memory_usage(cache->index)
+		*val = vmemcache_index_memory_usage(cache->index)
 			+ cache->repl->ops->dram_per_entry
 				* (cache->put_count - cache->evict_count);
 		break;

--- a/src/vmemcache.h
+++ b/src/vmemcache.h
@@ -74,7 +74,6 @@ struct vmemcache {
 	stat_t get_count;		/* total number of gets */
 	stat_t miss_count;		/* total number of misses */
 	stat_t evict_count;		/* total number of evicts */
-	stat_t size_DRAM;		/* current size of DRAM used for keys */
 };
 
 struct cache_entry {

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -249,3 +249,17 @@ vmemcache_index_memory_usage(struct index *index)
 
 	return entries + nodes * sizeof(struct critnib_node);
 }
+
+/*
+ * vmemcache_entry_count -- query the number of stored entries
+ */
+size_t
+vmemcache_entry_count(struct index *index)
+{
+	size_t leaves = 0;
+
+	for (int i = 0; i < NSHARDS; i++)
+		leaves += index->bucket[i]->leaf_count;
+
+	return leaves;
+}

--- a/src/vmemcache_index.h
+++ b/src/vmemcache_index.h
@@ -53,7 +53,7 @@ int vmcache_index_insert(struct index *index,
 int vmcache_index_get(struct index *index, const void *key, size_t ksize,
 			struct cache_entry **entry);
 int vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry);
-size_t vmemcache_index_internal_memory_usage(struct index *index);
+size_t vmemcache_index_memory_usage(struct index *index);
 
 #ifdef __cplusplus
 }

--- a/src/vmemcache_index.h
+++ b/src/vmemcache_index.h
@@ -54,6 +54,7 @@ int vmcache_index_get(struct index *index, const void *key, size_t ksize,
 			struct cache_entry **entry);
 int vmcache_index_remove(VMEMcache *cache, struct cache_entry *entry);
 size_t vmemcache_index_memory_usage(struct index *index);
+size_t vmemcache_entry_count(struct index *index);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
It takes adding 256 values to query this stuff, without a need for extra locks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/207)
<!-- Reviewable:end -->
