### PR TITLE
test: do not print out csv output in tests

### DIFF
--- a/tests/test-utilization.cmake
+++ b/tests/test-utilization.cmake
@@ -36,6 +36,6 @@ set(TIMEOUT_SEC 2)
 setup()
 
 execute(0 ${TEST_DIR}/vmemcache_test_utilization -d ${TEST_POOL_LOCATION}
-		-t ${TIMEOUT_SEC})
+		-t ${TIMEOUT_SEC} -n)
 
 cleanup()

--- a/tests/vmemcache_test_utilization.c
+++ b/tests/vmemcache_test_utilization.c
@@ -60,6 +60,7 @@ typedef struct {
 	size_t val_max;
 	char dir[PATH_MAX];
 	long seconds;
+	int print_output;
 } test_params;
 
 static const char *usage_str = "usage: %s "
@@ -70,7 +71,9 @@ static const char *usage_str = "usage: %s "
 	"[-t <timeout_seconds>] "
 	"[-m <timeout_minutes>] "
 	"[-o <timeout_hours>] "
-	"[-h]\n";
+	"[-n] "
+	"[-h]\n"
+	"\t n  -  do not print out csv output (it is printed by default)\n";
 
 
 /*
@@ -136,10 +139,11 @@ parse_args(int argc, char **argv)
 		.val_max = 0,
 		.dir = "",
 		.seconds = 0,
+		.print_output = 1,
 	};
 	size_t val_max_factor = 70;
 
-	const char *optstr = "hp:s:v:t:m:o:d:";
+	const char *optstr = "hp:s:v:t:m:o:d:n";
 	int opt;
 	long seconds = 0;
 	long minutes = 0;
@@ -174,6 +178,9 @@ parse_args(int argc, char **argv)
 			if (*optarg == 0)
 				argerror("invalid dir argument\n", argv[0]);
 			strcpy(p.dir, optarg);
+			break;
+		case 'n':
+			p.print_output = 0;
 			break;
 		default:
 			argerror("", argv[0]);
@@ -270,11 +277,13 @@ put_until_timeout(VMEMcache *vc, const test_params *p)
 		 * intent is to avoid unnecessary bloating of the csv output.
 		 */
 		ratio = (float)used_size / (float)p->pool_size;
-		print_ratio = keynum == 0 || lroundf(ratio * 100)
-			!= lroundf(prev_ratio * 100);
-		if (print_ratio) {
-			printf("%zu,%.3f\n", keynum, ratio);
-			prev_ratio = ratio;
+		if (p->print_output) {
+			print_ratio = keynum == 0 || lroundf(ratio * 100)
+				!= lroundf(prev_ratio * 100);
+			if (print_ratio) {
+				printf("%zu,%.3f\n", keynum, ratio);
+				prev_ratio = ratio;
+			}
 		}
 
 		if (info.evicted && ratio < ALLOWED_RATIO) {


### PR DESCRIPTION
vmemcache_test_utilization prints out a CSV output by default.
This may cause the Travis test to fail, due to exceeding the limit
of a log length. This patch adds an option ('-n') to disable
printing out a CSV output and disables it in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/213)
<!-- Reviewable:end -->
