### PR TITLE
Use fast-hash for sharding.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
 	util_posix.c
 	file.c
 	file_posix.c
+	fast-hash.c
 	mmap.c
 	mmap_posix.c
 	libvmemcache.c

--- a/src/fast-hash.c
+++ b/src/fast-hash.c
@@ -1,0 +1,64 @@
+/*
+ * The fast-hash algorithm is covered by the MIT License:
+ *
+ * Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "fast-hash.h"
+#include <endian.h>
+
+/*
+ * mix -- (internal) helper for the fast-hash mixing step
+ */
+static inline uint64_t
+mix(uint64_t h)
+{
+	h ^= h >> 23;
+	h *= 0x2127599bf4325c37ULL;
+	return h ^ h >> 47;
+}
+
+/*
+ * hash --  calculate the hash of a piece of memory
+ */
+uint64_t
+hash(size_t key_size, const char *key)
+{
+	/* fast-hash, by Zilong Tan */
+	const uint64_t    m = 0x880355f21e6d1965ULL;
+	const uint64_t *pos = (const uint64_t *)key;
+	const uint64_t *end = pos + (key_size / 8);
+	uint64_t h = key_size * m;
+
+	while (pos != end)
+		h = (h ^ mix(*pos++)) * m;
+
+	if (key_size & 7) {
+		uint64_t shift = (key_size & 7) * 8;
+		uint64_t mask = (1ULL << shift) - 1;
+		uint64_t v = htole64(*pos) & mask;
+		h = (h ^ mix(v)) * m;
+	}
+
+	return mix(h);
+}

--- a/src/fast-hash.h
+++ b/src/fast-hash.h
@@ -1,0 +1,34 @@
+/*
+ * The fast-hash algorithm is covered by the MIT License:
+ *
+ * Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FAST_HASH_H
+#define FAST_HASH_H 1
+
+#include <stdint.h>
+#include <stddef.h>
+uint64_t hash(size_t key_size, const char *key);
+
+#endif

--- a/src/vmemcache_index.c
+++ b/src/vmemcache_index.c
@@ -42,6 +42,7 @@
 #include "vmemcache.h"
 #include "vmemcache_index.h"
 #include "critnib.h"
+#include "fast-hash.h"
 #include "sys_util.h"
 
 #ifdef STATS_ENABLED
@@ -64,12 +65,7 @@ struct index {
 static int
 shard_id(size_t key_size, const char *key)
 {
-	/* Fowler–Noll–Vo hash */
-	uint64_t h = 0xcbf29ce484222325;
-	for (size_t i = 0; i < key_size; i++)
-		h = (h ^ (unsigned char)*key++) * 0x100000001b3;
-
-	return h & (NSHARDS - 1);
+	return (int)hash(key_size, key) & (NSHARDS - 1);
 }
 
 /*

--- a/utils/check_license/file-exceptions.sh
+++ b/utils/check_license/file-exceptions.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,4 +33,4 @@
 
 # file-exceptions.sh - filter out files not checked for copyright and license
 
-grep -v -E -e '/queue.h$'
+grep -v -E -e '/queue.h$|fast-hash'


### PR DESCRIPTION
In an index-only benchmark, improves time from 2.26 to 1.97.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/217)
<!-- Reviewable:end -->
