### PR TITLE
doc: update info about VMEMCACHE_STAT_DRAM_SIZE_USED in vmemcache manual

### DIFF
--- a/doc/vmemcache.md
+++ b/doc/vmemcache.md
@@ -193,7 +193,6 @@ respectively. The extra *arg* will be passed to your function.
 	-- *current* number of cache entries
     + **VMEMCACHE_STAT_DRAM_SIZE_USED**
 	-- current amount of DRAM used for keys
-	CLARIFY/RENAME: doesn't include index, repl nor allocator
     + **VMEMCACHE_STAT_POOL_SIZE_USED**
 	-- current usage of data pool
     + **VMEMCACHE_STAT_HEAP_ENTRIES**


### PR DESCRIPTION
VMEMCACHE_STAT_DRAM_SIZE_USED does include DRAM size used by:
- index,
- replication policy and
- allocator
since the following commit:
7630c8 Include repl overhead in the DRAM stat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/222)
<!-- Reviewable:end -->
