### PR TITLE
Set inode attributes to enable nocow.

### DIFF
--- a/src/mmap.c
+++ b/src/mmap.c
@@ -41,6 +41,8 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 #include "file.h"
 #include "mmap.h"
@@ -111,6 +113,28 @@ util_unmap(void *addr, size_t len)
 }
 
 /*
+ * chattr -- (internal) set file attributes
+ */
+static void
+chattr(int fd, int set, int clear)
+{
+	int attr;
+
+	if (ioctl(fd, FS_IOC_GETFLAGS, &attr) < 0) {
+		LOG(3, "!ioctl(FS_IOC_GETFLAGS) failed");
+		return;
+	}
+
+	attr |= set;
+	attr &= ~clear;
+
+	if (ioctl(fd, FS_IOC_SETFLAGS, &attr) < 0) {
+		LOG(3, "!ioctl(FS_IOC_SETFLAGS) failed");
+		return;
+	}
+}
+
+/*
  * util_map_tmpfile -- reserve space in an unlinked file and memory-map it
  *
  * size must be multiple of page size.
@@ -131,6 +155,8 @@ util_map_tmpfile(const char *dir, size_t size, size_t req_align)
 		LOG(2, "cannot create temporary file in dir %s", dir);
 		goto err;
 	}
+
+	chattr(fd, FS_NOCOW_FL, 0);
 
 	if ((errno = os_posix_fallocate(fd, 0, (os_off_t)size)) != 0) {
 		ERR("!posix_fallocate");


### PR DESCRIPTION
On btrfs, this disables its data crash safety features, improving performance and avoiding ENOSPC.  The CoW mode is enabled by default even on DAX — it copies every page once per commit (usually 30 seconds).  That's a huge waste of time for a volatile cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/230)
<!-- Reviewable:end -->
