### PR TITLE
Remove unused code for Coverity

### DIFF
--- a/src/out.h
+++ b/src/out.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,16 +51,14 @@ extern "C" {
  * Suppress errors which are after appropriate ASSERT* macro for nondebug
  * builds.
  */
-#if !defined(DEBUG) && (defined(__clang_analyzer__) || defined(__COVERITY__) ||\
-		defined(__KLOCWORK__))
+#if !defined(DEBUG) && (defined(__clang_analyzer__) || defined(__KLOCWORK__))
 #define OUT_FATAL_DISCARD_NORETURN __attribute__((noreturn))
 #else
 #define OUT_FATAL_DISCARD_NORETURN
 #endif
 
 #ifndef EVALUATE_DBG_EXPRESSIONS
-#if defined(DEBUG) || defined(__clang_analyzer__) || defined(__COVERITY__) ||\
-	defined(__KLOCWORK__)
+#if defined(DEBUG) || defined(__clang_analyzer__) || defined(__KLOCWORK__)
 #define EVALUATE_DBG_EXPRESSIONS 1
 #else
 #define EVALUATE_DBG_EXPRESSIONS 0

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,20 +48,6 @@
 #
 
 set -e
-
-if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
-	&& "$COVERITY" -eq 1 ]]; then
-	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
-		"'cron' nor by a push to 'coverity_scan' branch"
-	exit 0
-fi
-
-if [[ ( "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" )\
-	&& "$COVERITY" -ne 1 ]]; then
-	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
-		" or by a push to 'coverity_scan' branch"
-	exit 0
-fi
 
 if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	echo "ERROR: The variables OS and OS_VER have to be set properly " \


### PR DESCRIPTION
There is some code checks for Coverity, which are never used. I believe it can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/237)
<!-- Reviewable:end -->
