### PR TITLE
fix a time_t wraparound on 32-bit

### DIFF
--- a/benchmarks/benchmark_time.c
+++ b/benchmarks/benchmark_time.c
@@ -60,8 +60,8 @@ void
 benchmark_time_diff(benchmark_time_t *d, benchmark_time_t *t1,
 		    benchmark_time_t *t2)
 {
-	long long nsecs = (t2->tv_sec - t1->tv_sec) * NSECPSEC + t2->tv_nsec -
-		t1->tv_nsec;
+	long long nsecs = ((long long)t2->tv_sec - t1->tv_sec) * NSECPSEC
+		+ t2->tv_nsec - t1->tv_nsec;
 	assert(nsecs >= 0);
 	d->tv_sec = nsecs / NSECPSEC;
 	d->tv_nsec = nsecs % NSECPSEC;


### PR DESCRIPTION
Causes a random test failure on slow machines.  Revealed by Reproducible Builds where eg. i386 [failed every time](https://tests.reproducible-builds.org/debian/history/vmemcache.html), but I didn't notice that until now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/243)
<!-- Reviewable:end -->
