### PR TITLE
don't let gcc replace Zalloc

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -53,14 +53,6 @@ unsigned long long Pagesize;
 unsigned long long Mmap_align;
 
 /*
- * our versions of malloc & friends start off pointing to the libc versions
- */
-Malloc_func Malloc = malloc;
-Free_func Free = free;
-Realloc_func Realloc = realloc;
-Strdup_func Strdup = strdup;
-
-/*
  * Zalloc -- allocate zeroed memory
  */
 void *
@@ -222,21 +214,6 @@ util_checksum_seq(const void *addr, size_t len, uint64_t csum)
 		hi32 += lo32;
 	}
 	return (uint64_t)hi32 << 32 | lo32;
-}
-
-/*
- * util_set_alloc_funcs -- allow one to override malloc, etc.
- */
-void
-util_set_alloc_funcs(void *(*malloc_func)(size_t size),
-		void (*free_func)(void *ptr),
-		void *(*realloc_func)(void *ptr, size_t size),
-		char *(*strdup_func)(const char *s))
-{
-	Malloc = (malloc_func == NULL) ? malloc : malloc_func;
-	Free = (free_func == NULL) ? free : free_func;
-	Realloc = (realloc_func == NULL) ? realloc : realloc_func;
-	Strdup = (strdup_func == NULL) ? strdup : strdup_func;
 }
 
 /*

--- a/src/util.c
+++ b/src/util.c
@@ -56,8 +56,10 @@ unsigned long long Mmap_align;
  * Zalloc -- allocate zeroed memory
  */
 void *
+__attribute__((optimize(0)))
 Zalloc(size_t sz)
 {
+	/* gcc likes to replace this function as calloc() if optimizing */
 	void *ret = Malloc(sz);
 	if (!ret)
 		return NULL;

--- a/src/util.h
+++ b/src/util.h
@@ -76,15 +76,10 @@ extern unsigned long long Mmap_align;
 /*
  * overridable names for malloc & friends used by this library
  */
-typedef void *(*Malloc_func)(size_t size);
-typedef void (*Free_func)(void *ptr);
-typedef void *(*Realloc_func)(void *ptr, size_t size);
-typedef char *(*Strdup_func)(const char *s);
-
-extern Malloc_func Malloc;
-extern Free_func Free;
-extern Realloc_func Realloc;
-extern Strdup_func Strdup;
+#define Malloc malloc
+#define Free free
+#define Realloc realloc
+#define Strdup strdup
 extern void *Zalloc(size_t sz);
 
 void util_init(void);
@@ -117,12 +112,6 @@ int util_toUTF8_buff(const wchar_t *in, char *out, size_t out_size);
 
 #define UTIL_MAX_ERR_MSG 128
 void util_strerror(int errnum, char *buff, size_t bufflen);
-
-void util_set_alloc_funcs(
-		void *(*malloc_func)(size_t size),
-		void (*free_func)(void *ptr),
-		void *(*realloc_func)(void *ptr, size_t size),
-		char *(*strdup_func)(const char *s));
 
 /*
  * Macro calculates number of elements in given table


### PR DESCRIPTION
We were using two different layers of indirection (explicit named function pointers, symbol replacement) to intercept malloc&friends.  But as gcc became smarter, it learned how to peel off these layers — and then it noticed the Zalloc function could be turned into a calloc.

Thus, two commits here:
* drop one of these indirection layers
* disallow gcc to optimize Zalloc

This fixes test failures on Fedora (which uses LTO by default); non-test code doesn't replace malloc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/248)
<!-- Reviewable:end -->
