### PR TITLE
Fix redundant radix buckets on strings with 8th bit set.

### DIFF
--- a/src/critnib.c
+++ b/src/critnib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019, Intel Corporation
+ * Copyright 2018-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -211,7 +211,8 @@ critnib_set(struct critnib *c, struct cache_entry *e)
 
 	/* Calculate the divergence point within the single byte. */
 	char at = nkey[diff] ^ key[diff];
-	bitn_t sh = util_mssb_index((uint32_t)at) & (bitn_t)~(SLICE - 1);
+	bitn_t sh = util_mssb_index((uint32_t)(uint8_t)at)
+		& (bitn_t)~(SLICE - 1);
 
 	/* Descend into the tree again. */
 	n = c->root;


### PR DESCRIPTION
This bug doesn't affect correctness, but degrades performance of index operations.

Thanks to @igchor for noticing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmemcache/249)
<!-- Reviewable:end -->
